### PR TITLE
feat(technical-documentation): add full docs-surface repo audits (v0.1.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,11 @@ Skills are managed using vercel-labs/agent-skills (skills.sh/docs).
 
 1. Read `CONTRIBUTING.md` before making changes in this repo.
 2. Make targeted edits to skill files and references.
-3. Run relevant formatters/test commands when scripts or code are changed.
+3. Run validation gates before finalizing:
+   - `make validate`
+   - `pre-commit run --all-files`
+   - `make check-generated`
+   - if generated artifacts are out of date, run `make marketplace && make releases-index` and re-run `make check-generated`
 4. Open PRs as drafts first when applicable.
 
 ## Skill Standards

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -39,7 +39,7 @@ skills:
     path: skills/technical-documentation
     source: local
     tags: [docs, writing, review, evergreen, brownfield]
-    version: 0.1.2
+    version: 0.1.3
 
   - id: technical-integrations
     name: Technical Integrations

--- a/skills/technical-documentation/SKILL.md
+++ b/skills/technical-documentation/SKILL.md
@@ -17,6 +17,7 @@ Produce and review technical documentation that is clear, actionable, and mainta
 - Creating or overhauling docs in an existing product/codebase (brownfield).
 - Building evergreen docs meant to stay accurate and reusable over time.
 - Reviewing doc diffs for structure, clarity, and operational correctness.
+- Running full-repo documentation audits that must include both governance files and product docs surfaces (`docs/`, `README*`, `.md/.mdx/.mdc`, Fern/Sphinx/Mintlify-style sources).
 - Updating or reviewing AGENTS.md and/or CONTRIBUTING.md to keep agent and contributor workflows aligned with current repo practices.
 - Improving repository onboarding/docs that include contribution instructions, issue templates, PR flow, and review gates.
 - Designing governance documentation strategy for repos with alias instruction files (for example `CLAUDE.md`, `AGENT.md`, `.cursorrules`, `.cursor/rules/*`, `.agent/`, `.agents/`, `.pi/`) where `CLAUDE.md` is treated as a canonical policy source and `AGENTS.md` should be kept as compatibility alias if present.
@@ -25,17 +26,18 @@ Produce and review technical documentation that is clear, actionable, and mainta
 ## Workflow
 
 1. Classify task: `build` or `review`; context: `brownfield` or `evergreen`.
-2. Read `references/agent-and-contributing.md` for agent instruction and `CONTRIBUTING.md` workflow rules (inventory, canonical/alias mapping, dual-mode balance, deliverable standards, and precedence/conflict handling).
-3. Read `references/principles.md` for the governing ruleset (Matt Palmer & OpenAI).
-4. For build tasks, follow `references/build.md`.
-5. For review tasks, follow `references/review.md` and proactively detect issues without waiting for repeated prompts.
-6. For complex or high-risk tasks (build or review), it is acceptable to run longer, deeper, and more exhaustive investigations when needed for confidence.
-7. When available, use sub-agents for bounded parallel discovery/review work, then merge outputs into one coherent final deliverable.
-8. Use `references/tooling.md` when platform/tooling choices affect recommendations.
-9. Run a proactive issue sweep for agent/contributor surfaces and fix high-confidence documentation/rule defects in the same pass unless explicitly asked for report-only mode.
-10. In brownfield mode, prioritize compatibility with current docs IA, tooling, and release state.
-11. In evergreen mode, prioritize timeless wording, update strategy, and durable structure.
-12. Return deliverables plus validation notes and remaining gaps.
+2. Inventory full documentation scope early (governance + product docs): AGENTS/CONTRIBUTING/aliases plus docs directories, framework sources, and root/module READMEs.
+3. Read `references/agent-and-contributing.md` for agent instruction and `CONTRIBUTING.md` workflow rules (inventory, canonical/alias mapping, dual-mode balance, deliverable standards, and precedence/conflict handling).
+4. Read `references/principles.md` for the governing ruleset (Matt Palmer & OpenAI).
+5. For build tasks, follow `references/build.md`.
+6. For review tasks, follow `references/review.md` and proactively detect issues without waiting for repeated prompts.
+7. For complex or high-risk tasks (build or review), it is acceptable to run longer, deeper, and more exhaustive investigations when needed for confidence.
+8. When available, use sub-agents for bounded parallel discovery/review work, then merge outputs into one coherent final deliverable.
+9. Use `references/tooling.md` when platform/tooling choices affect recommendations.
+10. Run a proactive issue sweep for both governance and docs-content surfaces, and fix high-confidence defects in the same pass unless explicitly asked for report-only mode.
+11. In brownfield mode, prioritize compatibility with current docs IA, tooling, and release state.
+12. In evergreen mode, prioritize timeless wording, update strategy, and durable structure.
+13. Return deliverables plus validation notes and remaining gaps.
 
 ## Inputs
 
@@ -44,6 +46,7 @@ Produce and review technical documentation that is clear, actionable, and mainta
 - Docs framework/tooling constraints (Fern, Mintlify, Sphinx, etc.).
 - Build/review mode and brownfield/evergreen intent.
 - Target agent and human compatibility intent.
+- Docs framework surfaces in scope (for example Fern, Sphinx, Mintlify, Markdown/MDX/MDC/RST/RSC files).
 - Desired investigation depth/time budget (quick pass vs exhaustive review).
 - Execution mode (`single-agent` or `sub-agent-assisted` when available).
 - Remediation mode (`apply-fixes` by default, or `report-only` when requested).
@@ -55,5 +58,6 @@ Produce and review technical documentation that is clear, actionable, and mainta
 - Navigation/maintenance recommendations for long-term quality.
 - Governance-doc alignment summary when AGENTS/CONTRIBUTING were touched.
 - Agent instruction-surface map (primary file, alias files, Codex/Claude/Cursor handling plan).
+- Documentation-surface coverage map (what was reviewed under `/docs`, README hierarchy, and framework-specific source trees).
 - Autodetected issue list with applied fixes (or explicit report-only findings).
 - Delegation notes when sub-agents were used (scope delegated and how findings were merged).

--- a/skills/technical-documentation/references/build.md
+++ b/skills/technical-documentation/references/build.md
@@ -12,21 +12,28 @@ Read `principles.md` first, then follow this execution flow.
   - nested-agent rules, command/test requirements, PR workflow, and style checks.
 - Use the same command and validation expectations in proposed snippets and examples.
 
-## 2. Define intent and success
+## 2. Inventory product documentation surfaces (not governance only)
+
+- For repo-wide builds, include docs content surfaces in addition to AGENTS/CONTRIBUTING.
+- Inventory docs files and frameworks in scope (examples): `README*.md`, `docs/**`, `**/*.md`, `**/*.mdx`, `**/*.mdc`, `**/*.rst`, `**/*.rsc`, Fern/Mintlify config, Sphinx `conf.py`.
+- Build a coverage map before drafting so governance and product docs are both represented.
+- If scope is ambiguous, default to broader docs discovery first, then narrow intentionally.
+
+## 3. Define intent and success
 
 - Audience, prerequisites, and job-to-be-done.
 - Expected reader outcome immediately after completion.
 - Doc type: tutorial, how-to, reference, explanation.
 - Success criteria: what must be true after publish.
 
-## 3. Build structure before prose
+## 4. Build structure before prose
 
 - Follow the funnel: what/why, quickstart, next steps.
 - Keep headings informative and scannable.
 - Open each section with the takeaway sentence.
 - Add decision points with concrete branch guidance.
 
-## 4. Build AGENTS.md and CONTRIBUTING.md intentionally
+## 5. Build AGENTS.md and CONTRIBUTING.md intentionally
 
 - Keep AGENTS.md structure consistent with `agents.md` ecosystem patterns:
   - include YAML frontmatter when present in repo style (`name`, `description`).
@@ -40,7 +47,7 @@ Read `principles.md` first, then follow this execution flow.
 - If a required canonical entry file is missing (for example referenced `README.md` under a major directory), create the file in the same pass instead of adding a caveat-only note.
 - For new entry files, keep them minimal and actionable: purpose, prerequisites, concrete run commands, and pointers to deeper docs.
 
-## 5. Keep agent context tight
+## 6. Keep agent context tight
 
 - Author once, expose twice:
   - keep one shared policy core and avoid duplicating guidance in separate agent-specific files.
@@ -50,37 +57,38 @@ Read `principles.md` first, then follow this execution flow.
 - For Codex, prefer explicit file references and concrete paths for exact reuse.
 - Avoid adding unrelated historical or process details to avoid token/context drift during future tool reads.
 
-## 6. Brownfield build mode
+## 7. Brownfield build mode
 
 - Match existing terminology, navigation, and component patterns.
 - Preserve existing IA unless there is a documented migration plan.
 - For rewrites, include a migration note from old to new paths.
 - Prefer smallest safe change set that improves utility.
 
-## 7. Evergreen build mode
+## 8. Evergreen build mode
 
 - Prefer stable concepts over release-tied narrative.
 - Isolate volatile details under clearly marked version sections.
 - Include maintenance signals: owners, refresh triggers, stale criteria.
 - Include lifecycle notes: deprecation and replacement paths.
 
-## 8. Writing constraints
+## 9. Writing constraints
 
 - Use precise language and short, imperative instructions.
 - Keep code examples copy-ready and self-contained.
 - Include common failure modes and safe defaults.
 - Avoid placeholder guidance that cannot be executed.
 
-## 9. Agent and automation readiness
+## 10. Agent and automation readiness
 
 - Keep key facts in text (not image-only).
 - Prefer structured lists/tables when choices matter.
 - Add links and anchors that allow deterministic navigation.
 - Document what can be checked automatically in CI.
 
-## 10. Build validation
+## 11. Build validation
 
 - Validate commands and snippets where possible.
 - Verify links and references in changed sections.
 - Run a reference existence sweep for every path/command you introduced.
+- Verify docs-framework consistency when in scope (for example Sphinx/Fern config and referenced doc paths).
 - Record unresolved checks explicitly in handoff.

--- a/skills/technical-documentation/references/review.md
+++ b/skills/technical-documentation/references/review.md
@@ -7,6 +7,7 @@ Read `principles.md` first, then apply this checklist.
 - Identify doc type and target audience.
 - Confirm brownfield vs evergreen intent.
 - Confirm expected outcome for the reader.
+- For full-repo reviews, explicitly include both governance surfaces and product-doc surfaces (`docs/`, README trees, `.md/.mdx/.mdc`, `.rst/.rsc`, framework docs configs).
 
 ## 2. Investigation behavior
 
@@ -16,6 +17,7 @@ Read `principles.md` first, then apply this checklist.
 - When available, use sub-agents for bounded parallel discovery (for example file-inventory, command validation, or cross-doc consistency checks), then merge to one final issue set.
 - When no issues are found, state that explicitly and call out residual risks or validation gaps.
 - Default to `apply-fixes` for high-confidence documentation defects unless the user explicitly requests `report-only`.
+- Do not stop at AGENTS/CONTRIBUTING checks when the task is documentation-wide; continue into docs-content and docs-framework surfaces.
 
 ## 3. Governance surface review
 
@@ -49,35 +51,43 @@ For agent-platform awareness:
 - check for broken or missing referenced files (for example README/index files named as canonical entry points).
 - check for setup/command drift (for example non-existent install commands, root-level commands that should be module-scoped).
 
-## 4. Structural review
+## 4. Product documentation surface review
+
+- Verify docs IA coverage across root/module `README*` files and `docs/**` trees.
+- Review framework-native docs sources in scope (for example Fern, Mintlify, Sphinx, MkDocs) and ensure guidance matches actual source-of-truth files.
+- Check `.md/.mdx/.mdc/.rst/.rsc` for stale commands, missing prerequisites, and broken cross-links.
+- Confirm referenced doc paths and anchors exist.
+- Flag docs that should be split/merged to improve discoverability and maintenance.
+
+## 5. Structural review
 
 - Funnel check: what/why, quickstart, next steps.
 - Validate heading flow and navigation discoverability.
 - Flag critical content trapped in images or buried sections.
 - Check Diataxis alignment and split mixed-purpose sections.
 
-## 5. Writing quality review
+## 6. Writing quality review
 
 - Check for concise, scannable paragraphs.
 - Remove ambiguous pronouns and undefined terms.
 - Verify examples are executable and scoped correctly.
 - Verify tone is directive, technical, and non-hand-wavy.
 
-## 6. Brownfield review mode
+## 7. Brownfield review mode
 
 - Verify compatibility with existing docs IA and conventions.
 - Verify anchors, redirects, and cross-doc links remain valid.
 - Flag regressions in onboarding and task completion paths.
 - Ensure changed terminology is intentionally propagated.
 
-## 7. Evergreen review mode
+## 8. Evergreen review mode
 
 - Flag date-stamped or brittle wording without version scope.
 - Check ownership and refresh signals are present.
 - Ensure recommendations remain valid after routine product evolution.
 - Flag missing deprecation/migration guidance.
 
-## 8. Tooling and platform review
+## 9. Tooling and platform review
 
 Read `tooling.md` if platform fit is uncertain.
 
@@ -85,7 +95,7 @@ Read `tooling.md` if platform fit is uncertain.
 - Flag structure that fights the chosen docs platform.
 - Recommend targeted platform-aware improvements.
 
-## 9. Output format
+## 10. Output format
 
 1. Blocking issues (file + required fix)
 2. Non-blocking improvements


### PR DESCRIPTION
## Summary
- broaden `technical-documentation` skill so repo-wide reviews include product docs surfaces, not only AGENTS/CONTRIBUTING
- add explicit coverage for `docs/`, README trees, and framework-native docs sources (`.md/.mdx/.mdc/.rst/.rsc`, Fern/Sphinx/Mintlify-style surfaces)
- require coverage mapping in skill outputs and continue investigations past governance-only checks when scope is docs-wide
- bump `technical-documentation` skill version in `catalog.yaml` from `0.1.2` to `0.1.3`

## Validation
- `make validate`
- `pre-commit run --all-files`
- `make check-generated`
