### PR TITLE
feat(technical-documentation): sub-agent prompts + v0.1.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,10 @@ openai_yaml_defaults:
 
 - For external repos, run available unit tests and formatters before finalizing.
 - Use `gh` for PR operations and status checks.
+
+## Technical Documentation sub-agent prompt files
+
+- `/Users/vincentkoc/.codex/worktrees/16f3/agent-skills/skills/technical-documentation/agents/inventory-agent.md` (`fast`, Claude `haiku`)
+- `/Users/vincentkoc/.codex/worktrees/16f3/agent-skills/skills/technical-documentation/agents/governance-agent.md` (`thinking`, Claude `sonnet`)
+- `/Users/vincentkoc/.codex/worktrees/16f3/agent-skills/skills/technical-documentation/agents/docs-framework-agent.md` (`thinking`, Claude `sonnet`)
+- `/Users/vincentkoc/.codex/worktrees/16f3/agent-skills/skills/technical-documentation/agents/synthesis-agent.md` (`long`, Claude `opus`)

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -39,7 +39,7 @@ skills:
     path: skills/technical-documentation
     source: local
     tags: [docs, writing, review, evergreen, brownfield]
-    version: 0.1.3
+    version: 0.1.4
 
   - id: technical-integrations
     name: Technical Integrations

--- a/skills/technical-documentation/SKILL.md
+++ b/skills/technical-documentation/SKILL.md
@@ -39,6 +39,15 @@ Produce and review technical documentation that is clear, actionable, and mainta
 12. In evergreen mode, prioritize timeless wording, update strategy, and durable structure.
 13. Return deliverables plus validation notes and remaining gaps.
 
+## Sub-agent orchestration guidance
+
+Prefer sub-agents when the repo is large or the requested change set is broad; use them by default for repo-wide, multi-framework, or high-conflict work.
+
+- `inventory-agent` -> `agents/inventory-agent.md` (`fast` / Claude `haiku`): file/config discovery, coverage map, and missing-path checks.
+- `governance-agent` -> `agents/governance-agent.md` (`thinking` / Claude `sonnet`): AGENTS/CONTRIBUTING/alias precedence, conflicts, and policy drift.
+- `docs-framework-agent` -> `agents/docs-framework-agent.md` (`thinking` / Claude `sonnet`): framework config, relative path base, and file-path vs URL-path mapping checks.
+- `synthesis-agent` -> `agents/synthesis-agent.md` (`long` / Claude `opus`): merge sub-agent outputs into one prioritized fix plan and unified precedence model.
+
 ## Inputs
 
 - Doc type (tutorial, how-to, reference, explanation) and audience.

--- a/skills/technical-documentation/agents/docs-framework-agent.md
+++ b/skills/technical-documentation/agents/docs-framework-agent.md
@@ -1,0 +1,29 @@
+---
+name: docs-framework-agent
+description: Thinking-focused docs framework checker for config-relative paths and route/file mapping consistency.
+model: sonnet
+tools:
+  - Read
+  - Glob
+  - Grep
+permissionMode: default
+maxTurns: 10
+---
+
+You are the docs-framework sub-agent for technical documentation.
+
+Goals:
+- validate framework config-driven docs behavior
+- prevent path-mapping drift between source files and published routes
+
+Tasks:
+- detect and read framework config first (Fern/Sphinx/Mintlify/custom)
+- resolve paths relative to the declaring file/config
+- validate both maps:
+  - config -> file exists
+  - config/nav/routing -> URL path is valid and consistent
+
+Return:
+- config files reviewed
+- path assumptions made
+- mismatches (`missing file`, `stale route`, `wrong base path`)

--- a/skills/technical-documentation/agents/governance-agent.md
+++ b/skills/technical-documentation/agents/governance-agent.md
@@ -1,0 +1,27 @@
+---
+name: governance-agent
+description: Thinking-focused governance reviewer for AGENTS/CONTRIBUTING/alias precedence, conflict detection, and policy drift analysis.
+model: sonnet
+tools:
+  - Read
+  - Glob
+  - Grep
+permissionMode: default
+maxTurns: 10
+---
+
+You are the governance sub-agent for technical documentation.
+
+Goals:
+- validate AGENTS/CONTRIBUTING/alias alignment and precedence
+- identify policy drift and conflicting instructions
+
+Tasks:
+- determine canonical instruction source and alias compatibility mapping
+- detect conflicts across nested scope files and tool-specific rule consumers
+- validate command examples against stated governance expectations
+
+Return:
+- precedence model
+- conflict list with severity
+- recommended low-risk remediations

--- a/skills/technical-documentation/agents/inventory-agent.md
+++ b/skills/technical-documentation/agents/inventory-agent.md
@@ -1,0 +1,28 @@
+---
+name: inventory-agent
+description: Fast repo-surface discovery for technical documentation audits. Use for coverage mapping and missing-path detection before deeper review.
+model: haiku
+tools:
+  - Read
+  - Glob
+  - Grep
+  - LS
+permissionMode: default
+maxTurns: 6
+---
+
+You are the inventory sub-agent for technical documentation.
+
+Goals:
+- enumerate governance and docs-content surfaces in scope
+- detect missing files, broken references, and obvious command/path failures
+
+Tasks:
+- map `AGENTS.md`/`CONTRIBUTING.md`/aliases and docs surfaces (`docs/**`, README hierarchy, `.md/.mdx/.mdc/.rst/.rsc`)
+- list framework config files discovered (Fern/Sphinx/Mintlify or equivalent)
+- report hard failures only, with exact file paths
+
+Return:
+- coverage map
+- missing/broken path list
+- unresolved blockers

--- a/skills/technical-documentation/agents/synthesis-agent.md
+++ b/skills/technical-documentation/agents/synthesis-agent.md
@@ -1,0 +1,25 @@
+---
+name: synthesis-agent
+description: Long-context synthesis agent that merges sub-agent outputs into one prioritized and deduplicated documentation action plan.
+model: opus
+tools:
+  - Read
+permissionMode: default
+maxTurns: 12
+---
+
+You are the synthesis sub-agent for technical documentation.
+
+Goal:
+- merge sub-agent outputs into one coherent, non-duplicated action plan
+
+Tasks:
+- prioritize blockers first, then non-blocking improvements
+- normalize to one precedence model for governance decisions
+- remove duplicated recommendations and contradictory fixes
+- keep final output concise and execution-ready
+
+Return:
+- prioritized fix plan
+- validation summary (done vs pending)
+- explicit remaining gaps/blockers

--- a/skills/technical-documentation/references/build.md
+++ b/skills/technical-documentation/references/build.md
@@ -19,21 +19,31 @@ Read `principles.md` first, then follow this execution flow.
 - Build a coverage map before drafting so governance and product docs are both represented.
 - If scope is ambiguous, default to broader docs discovery first, then narrow intentionally.
 
-## 3. Define intent and success
+## 3. Framework config and path mapping rules
+
+- Detect framework/config first (for example Fern config, Sphinx `conf.py`, Mintlify config, or equivalent).
+- Resolve every referenced path relative to the file/config that declares it, not assumed repo root.
+- Treat filesystem paths and published URL routes as separate mappings; do not infer one from the other without config evidence.
+- Validate both layers:
+  - config -> file exists on disk
+  - config/nav/routing -> URL path is consistent and reachable
+- Record path-mapping assumptions and mismatches in handoff (`missing file`, `stale route`, `wrong base path`).
+
+## 4. Define intent and success
 
 - Audience, prerequisites, and job-to-be-done.
 - Expected reader outcome immediately after completion.
 - Doc type: tutorial, how-to, reference, explanation.
 - Success criteria: what must be true after publish.
 
-## 4. Build structure before prose
+## 5. Build structure before prose
 
 - Follow the funnel: what/why, quickstart, next steps.
 - Keep headings informative and scannable.
 - Open each section with the takeaway sentence.
 - Add decision points with concrete branch guidance.
 
-## 5. Build AGENTS.md and CONTRIBUTING.md intentionally
+## 6. Build AGENTS.md and CONTRIBUTING.md intentionally
 
 - Keep AGENTS.md structure consistent with `agents.md` ecosystem patterns:
   - include YAML frontmatter when present in repo style (`name`, `description`).
@@ -47,7 +57,7 @@ Read `principles.md` first, then follow this execution flow.
 - If a required canonical entry file is missing (for example referenced `README.md` under a major directory), create the file in the same pass instead of adding a caveat-only note.
 - For new entry files, keep them minimal and actionable: purpose, prerequisites, concrete run commands, and pointers to deeper docs.
 
-## 6. Keep agent context tight
+## 7. Keep agent context tight
 
 - Author once, expose twice:
   - keep one shared policy core and avoid duplicating guidance in separate agent-specific files.
@@ -57,35 +67,35 @@ Read `principles.md` first, then follow this execution flow.
 - For Codex, prefer explicit file references and concrete paths for exact reuse.
 - Avoid adding unrelated historical or process details to avoid token/context drift during future tool reads.
 
-## 7. Brownfield build mode
+## 8. Brownfield build mode
 
 - Match existing terminology, navigation, and component patterns.
 - Preserve existing IA unless there is a documented migration plan.
 - For rewrites, include a migration note from old to new paths.
 - Prefer smallest safe change set that improves utility.
 
-## 8. Evergreen build mode
+## 9. Evergreen build mode
 
 - Prefer stable concepts over release-tied narrative.
 - Isolate volatile details under clearly marked version sections.
 - Include maintenance signals: owners, refresh triggers, stale criteria.
 - Include lifecycle notes: deprecation and replacement paths.
 
-## 9. Writing constraints
+## 10. Writing constraints
 
 - Use precise language and short, imperative instructions.
 - Keep code examples copy-ready and self-contained.
 - Include common failure modes and safe defaults.
 - Avoid placeholder guidance that cannot be executed.
 
-## 10. Agent and automation readiness
+## 11. Agent and automation readiness
 
 - Keep key facts in text (not image-only).
 - Prefer structured lists/tables when choices matter.
 - Add links and anchors that allow deterministic navigation.
 - Document what can be checked automatically in CI.
 
-## 11. Build validation
+## 12. Build validation
 
 - Validate commands and snippets where possible.
 - Verify links and references in changed sections.

--- a/skills/technical-documentation/references/review.md
+++ b/skills/technical-documentation/references/review.md
@@ -59,35 +59,42 @@ For agent-platform awareness:
 - Confirm referenced doc paths and anchors exist.
 - Flag docs that should be split/merged to improve discoverability and maintenance.
 
-## 5. Structural review
+## 5. Framework config and path mapping checks
+
+- Detect and read framework config first (for example Fern config, Sphinx `conf.py`, Mintlify config, or equivalent).
+- Resolve path references relative to the declaring file/config.
+- Treat filesystem paths and published URL routes as separate maps; verify both.
+- Flag path-map drift explicitly (`missing file`, `stale route`, `wrong base path`).
+
+## 6. Structural review
 
 - Funnel check: what/why, quickstart, next steps.
 - Validate heading flow and navigation discoverability.
 - Flag critical content trapped in images or buried sections.
 - Check Diataxis alignment and split mixed-purpose sections.
 
-## 6. Writing quality review
+## 7. Writing quality review
 
 - Check for concise, scannable paragraphs.
 - Remove ambiguous pronouns and undefined terms.
 - Verify examples are executable and scoped correctly.
 - Verify tone is directive, technical, and non-hand-wavy.
 
-## 7. Brownfield review mode
+## 8. Brownfield review mode
 
 - Verify compatibility with existing docs IA and conventions.
 - Verify anchors, redirects, and cross-doc links remain valid.
 - Flag regressions in onboarding and task completion paths.
 - Ensure changed terminology is intentionally propagated.
 
-## 8. Evergreen review mode
+## 9. Evergreen review mode
 
 - Flag date-stamped or brittle wording without version scope.
 - Check ownership and refresh signals are present.
 - Ensure recommendations remain valid after routine product evolution.
 - Flag missing deprecation/migration guidance.
 
-## 9. Tooling and platform review
+## 10. Tooling and platform review
 
 Read `tooling.md` if platform fit is uncertain.
 
@@ -95,7 +102,7 @@ Read `tooling.md` if platform fit is uncertain.
 - Flag structure that fights the chosen docs platform.
 - Recommend targeted platform-aware improvements.
 
-## 10. Output format
+## 11. Output format
 
 1. Blocking issues (file + required fix)
 2. Non-blocking improvements


### PR DESCRIPTION
## Summary
- add dedicated technical-documentation sub-agent prompt files under `skills/technical-documentation/agents/`
- wire sub-agent references in `SKILL.md` as one-line model-tier mappings (`fast`, `thinking`, `long`)
- strengthen docs-framework pathing rules (config-relative resolution and file-path vs URL-path mapping checks)
- update catalog version for `technical-documentation` to `0.1.4`

## Validation
- `make ci`
