### PR TITLE
feat: vendor and sync /sectriage Codex slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ npx skills add vincentkoc/dotskills --list
 
 Default sync targets are managed automatically by vercel skills.
 
+## Codex slash commands
+
+This repo can also mirror Codex slash-command prompts from `vendor/` and sync them to `~/.codex/prompts`.
+
+- `make sync` now syncs skills and slash commands for the `codex` profile.
+- vendored command currently included: `/sectriage` from `steipete/agent-scripts`.
+
 ## Repository layout
 
 ```text

--- a/bin/agent-skills
+++ b/bin/agent-skills
@@ -23,6 +23,7 @@ Supported skill entry files:
 Profiles:
   codex  -> \
     \\${CODEX_HOME:-$HOME/.codex}/skills
+    (also syncs slash commands to \\${CODEX_HOME:-$HOME/.codex}/prompts)
   cursor -> \
     \\${CURSOR_SKILLS_DIR:-$HOME/.cursor/skills}
 USAGE
@@ -30,6 +31,10 @@ USAGE
 
 codex_target() {
   echo "${CODEX_HOME:-$HOME/.codex}/skills"
+}
+
+codex_prompts_target() {
+  echo "${CODEX_HOME:-$HOME/.codex}/prompts"
 }
 
 cursor_target() {
@@ -68,6 +73,19 @@ find_skill_dirs_under() {
   find "$base" -type f \( -name "SKILL.md" -o -name "AGENT.md" -o -name "AGENTS.md" \) -print \
     | sed -E 's#/(SKILL|AGENT|AGENTS)\.md$##' \
     | sort -u
+}
+
+list_slash_command_files() {
+  {
+    if [[ -d "$ROOT_DIR/slash-commands" ]]; then
+      find "$ROOT_DIR/slash-commands" -type f -name "*.md" -print
+    fi
+
+    if [[ -d "$VENDOR_DIR" ]]; then
+      find "$VENDOR_DIR" -type f -path "*/docs/slash-commands/*.md" -print
+      find "$VENDOR_DIR" -type f -path "*/slash-commands/*.md" -print
+    fi
+  } | sort -u
 }
 
 list_skills() {
@@ -122,6 +140,44 @@ link_or_copy_skill() {
   echo "$mode $src -> $dest"
 }
 
+link_or_copy_file() {
+  local src="$1"
+  local dest_root="$2"
+  local mode="$3"
+  local dry_run="$4"
+  local name
+  name="$(basename "$src")"
+  local dest="$dest_root/$name"
+
+  if [[ "$dry_run" == "true" ]]; then
+    echo "[dry-run] $mode $src -> $dest"
+    return 0
+  fi
+
+  mkdir -p "$dest_root"
+  rm -f "$dest"
+
+  if [[ "$mode" == "symlink" ]]; then
+    ln -s "$src" "$dest"
+  else
+    cp "$src" "$dest"
+  fi
+
+  echo "$mode $src -> $dest"
+}
+
+sync_codex_slash_commands() {
+  local mode="$1"
+  local dry_run="$2"
+  local target
+  target="$(codex_prompts_target)"
+
+  while IFS= read -r cmd_path; do
+    [[ -f "$cmd_path" ]] || continue
+    link_or_copy_file "$cmd_path" "$target" "$mode" "$dry_run"
+  done < <(list_slash_command_files)
+}
+
 sync_profile() {
   local profile="$1"
   local mode="$2"
@@ -147,6 +203,10 @@ sync_profile() {
     fi
     link_or_copy_skill "$skill_path" "$target" "$mode" "$dry_run"
   done < <(list_skills)
+
+  if [[ "$profile" == "codex" ]]; then
+    sync_codex_slash_commands "$mode" "$dry_run"
+  fi
 }
 
 catalog_has_id() {

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -27,6 +27,26 @@ skills:
       commit: 1ed29a03dc852d30fa6ef2ca53a67dc2c2c2c563
     tags: [upstream, imported]
 
+  - id: steipete-sectriage-reference
+    name: Steipete sectriage (reference)
+    path: vendor/steipete/agent-scripts/docs/slash-commands/sectriage.md
+    source: upstream
+    upstream:
+      type: webpage
+      url: https://github.com/steipete/agent-scripts/blob/main/docs/slash-commands/sectriage.md
+    tags: [upstream, reference, slash-command]
+
+  - id: steipete-sectriage
+    name: steipete/sectriage
+    path: vendor/steipete/agent-scripts/docs/slash-commands/sectriage.md
+    source: upstream
+    upstream:
+      type: git
+      repo: https://github.com/steipete/agent-scripts
+      ref: main
+      commit: 4e28dd5bd7caa5ba142c20f80325ac63d42ecf0e
+    tags: [upstream, imported, slash-command]
+
   - id: technical-deslop
     name: Technical Deslop
     path: skills/technical-deslop

--- a/skills/opik-integrations-auditor/agents/openai.yaml
+++ b/skills/opik-integrations-auditor/agents/openai.yaml
@@ -1,3 +1,4 @@
-display_name: Opik Integrations Auditor
-short_description: Audit and document Opik integration patterns.
-default_prompt: Review Opik integrations across Python, TypeScript, and OTEL/API. Produce a matrix, findings, and doc/test gap plan.
+interface:
+  display_name: "Opik Integrations Auditor"
+  short_description: "Audit and document Opik integration patterns."
+  default_prompt: "Review Opik integrations across Python, TypeScript, and OTEL/API. Produce a matrix, findings, and doc/test gap plan."

--- a/skills/technical-documentation/SKILL.md
+++ b/skills/technical-documentation/SKILL.md
@@ -27,17 +27,18 @@ Produce and review technical documentation that is clear, actionable, and mainta
 
 1. Classify task: `build` or `review`; context: `brownfield` or `evergreen`.
 2. Inventory full documentation scope early (governance + product docs): AGENTS/CONTRIBUTING/aliases plus docs directories, framework sources, and root/module READMEs.
-3. Read `references/agent-and-contributing.md` for agent instruction and `CONTRIBUTING.md` workflow rules (inventory, canonical/alias mapping, dual-mode balance, deliverable standards, and precedence/conflict handling).
-4. Read `references/principles.md` for the governing ruleset (Matt Palmer & OpenAI).
-5. For build tasks, follow `references/build.md`.
-6. For review tasks, follow `references/review.md` and proactively detect issues without waiting for repeated prompts.
-7. For complex or high-risk tasks (build or review), it is acceptable to run longer, deeper, and more exhaustive investigations when needed for confidence.
-8. When available, use sub-agents for bounded parallel discovery/review work, then merge outputs into one coherent final deliverable.
-9. Use `references/tooling.md` when platform/tooling choices affect recommendations.
-10. Run a proactive issue sweep for both governance and docs-content surfaces, and fix high-confidence defects in the same pass unless explicitly asked for report-only mode.
-11. In brownfield mode, prioritize compatibility with current docs IA, tooling, and release state.
-12. In evergreen mode, prioritize timeless wording, update strategy, and durable structure.
-13. Return deliverables plus validation notes and remaining gaps.
+3. Detect multilingual scope (README/docs in multiple languages) and define required parity level.
+4. Read `references/agent-and-contributing.md` for agent instruction and `CONTRIBUTING.md` workflow rules (inventory, canonical/alias mapping, dual-mode balance, deliverable standards, and precedence/conflict handling).
+5. Read `references/principles.md` for the governing ruleset (Matt Palmer & OpenAI).
+6. For build tasks, follow `references/build.md`.
+7. For review tasks, follow `references/review.md` and proactively detect issues without waiting for repeated prompts.
+8. For complex or high-risk tasks (build or review), it is acceptable to run longer, deeper, and more exhaustive investigations when needed for confidence.
+9. When available, use sub-agents for bounded parallel discovery/review work, then merge outputs into one coherent final deliverable.
+10. Use `references/tooling.md` when platform/tooling choices affect recommendations.
+11. Run a proactive issue sweep for both governance and docs-content surfaces, and fix high-confidence defects in the same pass unless explicitly asked for report-only mode.
+12. In brownfield mode, prioritize compatibility with current docs IA, tooling, and release state.
+13. In evergreen mode, prioritize timeless wording, update strategy, and durable structure.
+14. Return deliverables plus validation notes, parity status, and remaining gaps.
 
 ## Sub-agent orchestration guidance
 
@@ -59,6 +60,7 @@ Prefer sub-agents when the repo is large or the requested change set is broad; u
 - Desired investigation depth/time budget (quick pass vs exhaustive review).
 - Execution mode (`single-agent` or `sub-agent-assisted` when available).
 - Remediation mode (`apply-fixes` by default, or `report-only` when requested).
+- Multilingual scope: source-of-truth language, target locales, and parity expectations.
 
 ## Outputs
 
@@ -70,3 +72,4 @@ Prefer sub-agents when the repo is large or the requested change set is broad; u
 - Documentation-surface coverage map (what was reviewed under `/docs`, README hierarchy, and framework-specific source trees).
 - Autodetected issue list with applied fixes (or explicit report-only findings).
 - Delegation notes when sub-agents were used (scope delegated and how findings were merged).
+- Multilingual parity note (in-sync, partial with rationale, or intentionally divergent).

--- a/skills/technical-documentation/references/build.md
+++ b/skills/technical-documentation/references/build.md
@@ -101,4 +101,13 @@ Read `principles.md` first, then follow this execution flow.
 - Verify links and references in changed sections.
 - Run a reference existence sweep for every path/command you introduced.
 - Verify docs-framework consistency when in scope (for example Sphinx/Fern config and referenced doc paths).
+
+## 13. Multilingual parity mode (when applicable)
+
+- Pick one source-of-truth language for technical accuracy and release timing.
+- Define parity target: full parity, staged parity, or intentional divergence per section.
+- Keep structure aligned across locales (headings, anchors, section order) when possible.
+- Preserve command/code correctness first; localize explanatory text second.
+- If parity is not feasible, add a visible note with missing scope and expected sync window.
+- Run a locale parity check for changed sections (added/removed steps, warnings, prerequisites).
 - Record unresolved checks explicitly in handoff.

--- a/skills/technical-documentation/references/principles.md
+++ b/skills/technical-documentation/references/principles.md
@@ -46,3 +46,7 @@ For agent-instructions and contributor-governance specifics (AGENTS/aliases/CONT
 - Long-running and extensive investigations are allowed for both build and review work when needed to resolve ambiguity or cross-file drift.
 - Use sub-agents when available for bounded parallel discovery, verification, or cross-source comparison.
 - Keep one merged outcome: sub-agent outputs must be normalized into a single consistent recommendation/fix set.
+
+## Multilingual parity rule
+
+When docs exist in multiple languages, target cross-locale parity for task-critical content (steps, warnings, prerequisites, and limits). If full parity is not possible, publish explicit parity status and sync intent.

--- a/skills/technical-documentation/references/review.md
+++ b/skills/technical-documentation/references/review.md
@@ -102,7 +102,15 @@ Read `tooling.md` if platform fit is uncertain.
 - Flag structure that fights the chosen docs platform.
 - Recommend targeted platform-aware improvements.
 
-## 11. Output format
+## 11. Multilingual parity review (when applicable)
+
+- Confirm declared source-of-truth language and expected parity policy.
+- Compare changed sections across locales for step/order/warning drift.
+- Flag missing updates to prerequisites, version notes, limits, and safety guidance.
+- Allow intentional divergence only when rationale is explicit and user-impact is low.
+- Require a reader-visible status note when locale parity is partial.
+
+## 12. Output format
 
 1. Blocking issues (file + required fix)
 2. Non-blocking improvements

--- a/vendor/steipete/README.md
+++ b/vendor/steipete/README.md
@@ -1,0 +1,9 @@
+# Steipete references
+
+This folder tracks references or mirrored copies from `steipete/agent-scripts`.
+
+Current mirror:
+
+- `agent-scripts/docs/slash-commands/sectriage.md`
+
+Pinned provenance is recorded in `catalog.yaml`.

--- a/vendor/steipete/agent-scripts/docs/slash-commands/sectriage.md
+++ b/vendor/steipete/agent-scripts/docs/slash-commands/sectriage.md
@@ -1,0 +1,88 @@
+---
+summary: "Finish security advisory triage (land fix, gates, GHSA patch, ready-to-publish)."
+read_when:
+  - After discussion, when asked to finish GHSA triage end-to-end.
+argument-hint: "<ghsa-or-url?>"
+---
+# /sectriage
+
+Use after discussion. When you say “update this on GitHub via gh” (or you type `/sectriage`), that is consent for remote writes: I will patch the GHSA via `gh api` and verify.
+
+## Intent
+
+Default intent: land the fix on `main` directly (commit + push; no PR), update `CHANGELOG.md`, and keep the GHSA in a “ready to publish later” state. No separate/private PR workflow unless you explicitly ask.
+
+## Invocation Format (you paste, optional)
+
+Prefer minimal. If you only give `ghsa` (or URL), I will derive the rest from the repo + tags and only ask if something is ambiguous.
+
+- `repo`: `owner/name` (optional; default from `git remote`)
+- `ghsa`: `GHSA-....` (or advisory URL)
+- `severity`: `low|medium|high|critical`
+- `cvss`: full vector string (optional; but include if we want it set/restored)
+- `affected`: human range line for text (example: `<= 2026.2.13`)
+- `vuln_range`: GitHub structured `vulnerable_version_range` (example: `<=2026.2.13`)
+- `patched_versions`: planned fixed version (normally the version you’re about to ship next; from changelog/release prep)
+- `package`: usually `openclaw` (npm)
+- `credits`: reporter handle (example: `@akhmittra`)
+- `fix_commits`: one or more full SHAs (required once a fix is merged)
+- `summary`: 1-liner summary (no GHSA id)
+- `description_md`: full Markdown for advisory description (must include an “Affected Packages / Versions” section)
+
+## What I Do (execute, not suggest)
+
+1. Parse inputs. Derive `repo` from `git remote -v` if omitted. Extract GHSA id from URL if needed.
+2. Preflight:
+   - `git status --porcelain` (must be clean or only expected files)
+   - fetch advisory via `gh api …security-advisories/<GHSA>` and show current structured fields
+   - existing fix PR scan (prefer re-use; avoid duplicate fixes):
+     - if advisory has `private_fork.full_name`: `gh pr list -R <privateFork> --state open`
+     - also search upstream: `gh pr list -R <repo> --search "<GHSA>" --state all`
+     - if there’s a credible fix PR already:
+       - review via `gh pr view` / `gh pr diff`
+       - fetch PR head branch and cherry-pick commits (avoid local branch switching): `git fetch <remote> <headRef>` then `git cherry-pick <sha>…`
+   - fetch latest published versions:
+     - `npm view <pkg> version --userconfig "$(mktemp)"`
+     - update `vulnerable_version_range` to include that latest version if the issue still exists on `main`
+   - fixed-version rule (optimize for “press publish only”):
+     - use the planned next release version from `CHANGELOG.md` (if present) or `package.json`
+     - set `patched_versions` to that planned version even if npm publish hasn’t happened yet
+     - this keeps the advisory ready so the only follow-up action is “Publish” after npm is out
+3. Local verify (required):
+   - `pnpm check`
+   - `pnpm exec vitest run --config vitest.gateway.config.ts`
+   - `pnpm test:fast`
+4. Changelog:
+   - ensure `CHANGELOG.md` has `## Unreleased` + `### Fixes` entry
+   - no GHSA id mention
+   - includes thanks to reporter
+   - ensure wording implies it ships in the next npm release (that’s the whole point: no more ticket edits)
+   - commit only if changelog needed changes
+5. Git:
+   - if there are local commits ahead of origin: `git pull --rebase` then `git push`
+6. Similar-issue scan (read-only):
+   - list other `pathToFileURL(` + dynamic `import(` callsites
+   - list obvious path-join/resolve callsites
+   - if I find a credible escape bug: stop and report (do not “surprise-fix” during /sectriage)
+7. GHSA patch (remote write; invocation is consent):
+   - write `/tmp/ghsa.desc.md` from `description_md`
+   - required in `description_md`:
+     - explicit versions (latest published + affected ranges)
+     - “Fix Commit(s)” section with one or more full git SHAs (or “pending” if not merged yet)
+     - “Release Process Note”: patched version is pre-set to the planned next release; once npm release is out, just publish the advisory
+   - write `/tmp/ghsa.patch.json` with `summary`, `severity`, `description`, and `vulnerabilities[]`:
+     - `vulnerable_version_range` uses latest published npm version (usually `<=<npmVersion>`)
+     - `patched_versions` uses the planned next release version (from changelog/package.json)
+   - `gh api -X PATCH … --input /tmp/ghsa.patch.json`
+   - if `cvss` provided: patch `cvss_vector_string`
+8. Verify:
+   - re-fetch advisory, print `html_url`, `state`, `vulnerabilities`, `cvss`, `updated_at`
+   - print GHSA link
+
+## Implementation Notes (hard rules)
+
+- Avoid JSON quoting footguns:
+  - `description_md` goes to `/tmp/ghsa.desc.md`
+  - build JSON via `jq -n --rawfile desc /tmp/ghsa.desc.md …`
+- Advisory comments endpoint may not exist via REST; update via `description` + structured fields.
+- State transitions (accept/publish) likely UI/Publisher-only; do not attempt unless you explicitly ask.


### PR DESCRIPTION
## What changed
- resolved and incorporated the current documentation merge-conflict set in `skills/technical-documentation/*`
- vendored `/sectriage` from `steipete/agent-scripts` under `vendor/steipete/agent-scripts/docs/slash-commands/sectriage.md`
- extended `bin/agent-skills sync` so the `codex` profile also syncs slash-command markdown files to `~/.codex/prompts`
- added catalog/provenance entries and README notes for slash-command sync

## Why
- keep `/sectriage` sourced from vendored upstream content
- make it available as a native Codex slash command during normal sync flow
- preserve existing skill install/sync behavior

## Validation
- `make validate`
- `pre-commit run --all-files`
- `make check-generated`
- `./bin/agent-skills sync --profile codex --dry-run` (verified `vendor/steipete/agent-scripts/docs/slash-commands/sectriage.md` maps to `~/.codex/prompts/sectriage.md`)
