### PR TITLE
docs: group public skills for skills.sh

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Crawling & Archives",
+      "description": "Skills for maintaining crawl libraries, archive CLIs, and local GitHub crawl data.",
+      "skills": [
+        "crawlkit",
+        "ghcrawl-cluster-operator",
+        "graincrawl"
+      ]
+    },
+    {
+      "title": "Review & Operations",
+      "description": "Skills for GitHub dedupe, worktree hygiene, semantic review slices, and clean diffs.",
+      "skills": [
+        "openclaw-github-dedupe",
+        "operations-worktree",
+        "semantic-slicing",
+        "technical-deslop"
+      ]
+    },
+    {
+      "title": "Technical Authoring",
+      "description": "Skills for documentation, integration design, and discovering new skill opportunities.",
+      "skills": [
+        "technical-documentation",
+        "technical-integrations",
+        "technical-skill-finder"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I’m proposing collections on the ClawHub home page to improve discoverability and navigation across community skills, based on community signals. Since this is a public skill repo, this PR proposes categorizing its public skills with the `skills.sh.json` pattern documented at https://www.skills.sh/docs/customize, which Patrick Erichsen has already adopted in `openclaw/clawhub` to feed this kind of collection.

Example of where this would be used:

![ClawHub collections example](https://i.imgur.com/xj6FRYH.png)

![ClawHub collections detail example](https://i.imgur.com/H9wNCnS.png)

Adds a root `skills.sh.json` so skills.sh can show this repo's public skills in curated sections instead of relying on the default install-sorted list.

Scope:
- groups 10 public skills listed in `releases/skills.json`; remaining skills stay in the ungrouped section
- keeps `notGrouped` at `bottom` so internal, template, or future unlisted skills still appear without being promoted into a collection
- does not change any skill contents, generated release artifacts, or install behavior

Validation:
- parsed `skills.sh.json` with Node
- checked every listed slug exists in `releases/skills.json` and has `skills/<name>/SKILL.md`
- `make validate` (passes; `skills-ref` is not installed locally, so the external validator is skipped)
- `git diff --check origin/main...HEAD`

Maintainer validation at `7fd02344b95761e31191ecf4e62a259d1cc06464`: merged current main without changing the grouping file; `make validate`, `pre-commit run --all-files`, `make check-generated`, JSON/group uniqueness, and all 10 source-path checks passed. Independent source review found no actionable issue. Exact-head hosted validation and CodeQL were approved and are running.
