### PR TITLE
test(private-skills): guard batch sweep state ranking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: list validate validate-spec sync sync-copy precommit-install precommit-run import-anthropic import-anthropic-dry import-huggingface-dry marketplace releases-index check-generated changed-skills ci publish-skill release
+.PHONY: list validate validate-spec test sync sync-copy precommit-install precommit-run import-anthropic import-anthropic-dry import-huggingface-dry marketplace releases-index check-generated changed-skills ci publish-skill release
 
 list:
 	./bin/agent-skills list
@@ -8,6 +8,9 @@ validate:
 
 validate-spec:
 	./scripts/validate_spec.py
+
+test:
+	node --test private-skills/openclaw-pr-batch-sweep/scripts/*.test.mjs
 
 sync:
 	./bin/agent-skills sync --profile codex,cursor --mode symlink
@@ -42,7 +45,7 @@ check-generated:
 changed-skills:
 	./scripts/changed_skills.sh $(BASE) $(HEAD)
 
-ci: marketplace releases-index validate precommit-run check-generated
+ci: marketplace releases-index validate test precommit-run check-generated
 
 publish-skill:
 	./scripts/publish_skill.sh $(SKILL) $(TAG) $(REPO)

--- a/private-skills/openclaw-pr-batch-sweep/scripts/rank-candidates.test.mjs
+++ b/private-skills/openclaw-pr-batch-sweep/scripts/rank-candidates.test.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(new URL("./rank-candidates.mjs", import.meta.url));
+
+function hydratedPr(overrides = {}) {
+  return {
+    number: 12345,
+    title: "fix: preserve retry scheduling",
+    author: { login: "contributor" },
+    author_association: "CONTRIBUTOR",
+    state: "open",
+    draft: false,
+    changed_files: 2,
+    mergeable: true,
+    mergeable_state: "clean",
+    files: [
+      { filename: "src/retry.ts", additions: 15, deletions: 5 },
+      { filename: "src/retry.test.ts", additions: 10, deletions: 0 },
+    ],
+    statusCheckRollup: [],
+    ...overrides,
+  };
+}
+
+function runHydrated(pr) {
+  const result = spawnSync(process.execPath, [scriptPath, "--hydrated"], {
+    input: JSON.stringify([pr]),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+function checkRun(overrides) {
+  return {
+    workflowName: "CI",
+    name: "test",
+    ...overrides,
+  };
+}
+
+test("rejects an unresolved REST merge state even when mergeable is true", () => {
+  const output = runHydrated(hydratedPr({ mergeable_state: "unknown" }));
+
+  assert.equal(output.selected.length, 0);
+  assert.deepEqual(output.rejected[0].reasons, ["unresolved merge state"]);
+});
+
+for (const olderConclusion of ["FAILURE", "SUCCESS"]) {
+  test(`prefers a newer in-progress check over an older ${olderConclusion.toLowerCase()} check`, () => {
+    const output = runHydrated(
+      hydratedPr({
+        statusCheckRollup: [
+          checkRun({
+            status: "IN_PROGRESS",
+            conclusion: null,
+            startedAt: "2026-07-01T11:00:00Z",
+            completedAt: "0001-01-01T00:00:00Z",
+          }),
+          checkRun({
+            status: "COMPLETED",
+            conclusion: olderConclusion,
+            startedAt: "2026-07-01T10:00:00Z",
+            completedAt: "2026-07-01T10:10:00Z",
+          }),
+        ],
+      }),
+    );
+
+    assert.equal(output.rejected.length, 0);
+    assert.equal(output.selected.length, 1);
+    assert.equal(output.selected[0].score, 15);
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

The batch-sweep ranker already rejects hydrated PRs with an unresolved REST merge state and correctly treats GitHub's year-1 `completedAt` value as unset for in-progress checks. Those review fixes landed in #21 without regression coverage, so either behavior could regress silently.

## Why This Change Was Made

Add focused CLI-level tests for both state-selection rules and wire the repository test target into `make ci`. The fixtures cover an older completed failure and success followed by a newer in-progress run, ensuring both rejection and scoring behavior use the latest check.

## User Impact

Batch sweeps keep indeterminate merge states out of the final candidate list and do not rank PRs from stale check results.

## Evidence

- `make test`
- `make validate`
- `make check-generated`
- `pre-commit run --all-files`
- `make ci`
- autoreview: clean, no accepted/actionable findings
