### PR TITLE
chore(ci): move workflows to Node 24 actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,17 +19,17 @@ jobs:
     needs: verify-install
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.12.0"
 
@@ -118,7 +118,7 @@ jobs:
           npx -y skills add "https://github.com/${repo}/tree/${GITHUB_REF_NAME}" --list
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release-notes.md
           files: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.12.0"
 

--- a/.github/workflows/verify-install.yml
+++ b/.github/workflows/verify-install.yml
@@ -21,17 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.12.0"
 
       - name: Cache npm
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: skills-npm-${{ runner.os }}-node-22-${{ hashFiles('.github/workflows/verify-install.yml') }}


### PR DESCRIPTION
## What changed
- upgrade checkout, setup-node, setup-python, cache, and release actions to current Node 24 majors
- remove the deprecation warnings observed in the `v0.2.0` release run

## Validation
- `pre-commit run --all-files`
- workflow YAML and CodeQL guard pass
