### PR TITLE
fix(codebase-memory): canonicalize worktree indexes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "codebase-memory-mcp",
       "source": "./skills/codebase-memory-mcp",
       "skills": "./",
-      "description": "Bring up `codebase-memory-mcp` for a repository and prove the graph is usable before relying on it for code discovery."
+      "description": "Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph is usable before relying on it for code discovery. Keep linked worktrees on the owner's graph instead of creating one graph per branch."
     },
     {
       "name": "codex-goal-mining",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is my personal **.skills** repository for Codex, Cursor, OpenClaw and agent
 
 | Skill | What it does | Install |
 |---|---|---|
-| `codebase-memory-mcp` | Index repositories and operate graph-backed code discovery and its local UI. | `npx skills add vincentkoc/dotskills --skill codebase-memory-mcp -y` |
+| `codebase-memory-mcp` | Index canonical Git checkouts, operate graph discovery/UI, and audit duplicate worktree caches. | `npx skills add vincentkoc/dotskills --skill codebase-memory-mcp -y` |
 | `codex-goal-mining` | Mine local or fleet Codex goal history into evidence-backed rerun suites. | `npx skills add vincentkoc/dotskills --skill codex-goal-mining -y` |
 | `codex-session-recovery` | Recover Codex and Claude tmux sessions without overwriting restore evidence. | `npx skills add vincentkoc/dotskills --skill codex-session-recovery -y` |
 | `crabpot-perf-metrics` | Interpret Crabpot and OpenClaw performance artifacts without over-reading noise. | `npx skills add vincentkoc/dotskills --skill crabpot-perf-metrics -y` |

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -108,7 +108,7 @@ skills:
     path: skills/codebase-memory-mcp
     source: local
     tags: [codebase, graph, mcp, indexing, discovery]
-    version: 0.1.0
+    version: 0.2.0
 
   - id: codex-session-recovery
     name: Codex Session Recovery

--- a/releases/skills.json
+++ b/releases/skills.json
@@ -4,7 +4,7 @@
     {
       "name": "codebase-memory-mcp",
       "source": "./skills/codebase-memory-mcp",
-      "description": "Bring up `codebase-memory-mcp` for a repository and prove the graph is usable before relying on it for code discovery.",
+      "description": "Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph is usable before relying on it for code discovery. Keep linked worktrees on the owner's graph instead of creating one graph per branch.",
       "install": "npx skills add https://github.com/vincentkoc/dotskills --skill codebase-memory-mcp -y"
     },
     {

--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-memory-mcp
-description: Initialize, configure, index, start, verify, troubleshoot, or refresh codebase-memory-mcp knowledge graphs and the local HTTP graph UI. Use when a user mentions codebase memory MCP, search_graph, trace_path, graph UI, index_repository, or wants graph-backed code discovery for a repository.
+description: Resolve canonical Git checkouts, index and verify codebase-memory-mcp graphs, operate the local graph UI, and safely audit duplicate worktree caches. Use when a user mentions codebase memory MCP, search_graph, trace_path, graph UI, index_repository, worktree indexes, or oversized graph caches.
 license: MIT
 metadata:
   source: "https://github.com/vincentkoc/dotskills"
@@ -10,7 +10,7 @@ metadata:
 
 ## Purpose
 
-Bring up `codebase-memory-mcp` for a repository and prove the graph is usable before relying on it for code discovery.
+Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph is usable before relying on it for code discovery. Keep linked worktrees on the owner's graph instead of creating one graph per branch.
 
 ## When to use
 
@@ -18,6 +18,7 @@ Bring up `codebase-memory-mcp` for a repository and prove the graph is usable be
 - Start or inspect the local graph UI.
 - Use `search_graph`, `trace_path`, `get_code_snippet`, or `query_graph`.
 - Verify that a repository is indexed before graph-backed exploration.
+- Audit or prune duplicate linked-worktree indexes without deleting cache files directly.
 
 ## Workflow
 
@@ -26,23 +27,41 @@ Bring up `codebase-memory-mcp` for a repository and prove the graph is usable be
    - `git status -sb`
    - `command -v codebase-memory-mcp`
    - `codebase-memory-mcp --version`
-2. Prefer exposed MCP graph tools for discovery.
+2. Resolve the canonical owning checkout.
+   - `scripts/codebase-memory-graph.sh canonical --repo "$(git rev-parse --show-toplevel)"`
+   - Linked worktrees resolve through their absolute Git common directory to the one checkout that owns it.
+   - Separate clones remain separate projects.
+   - Missing, invalid, bare, or ownerless repositories fail closed.
+3. Prefer exposed MCP graph tools for discovery.
    - Run `index_repository` before searching when the repository is not indexed.
    - Use `search_graph`, `trace_path`, and `get_code_snippet` before broad text scans.
-3. Use the helper when CLI or UI orchestration is needed.
+4. Use the helper when CLI or UI orchestration is needed.
    - `scripts/codebase-memory-graph.sh init --repo "$(git rev-parse --show-toplevel)" --mode full`
+   - The helper always sends the canonical owning checkout to `index_repository`.
    - Use `--mode fast` for a smoke index.
-4. Verify the graph.
+5. Verify the graph.
    - `codebase-memory-mcp cli list_projects`
    - `scripts/codebase-memory-graph.sh schema --repo "$(git rev-parse --show-toplevel)"`
    - Run one focused graph query before declaring success.
-5. Verify the UI when requested.
+6. Verify the UI when requested.
    - Default URL: `http://127.0.0.1:9749/`.
    - The helper creates a repository-scoped tmux keepalive session.
-6. Report exact proof.
+7. Audit cache cleanup before applying it.
+   - Freeze a host-specific manifest:
+     `scripts/codebase-memory-graph.sh cache-audit --manifest /secure/path/cbm-cache.json`
+   - Missing roots are protected unless the audit names an explicit narrow `--ephemeral-prefix`.
+   - Linked-worktree candidates require a mapped, indexed, healthy full canonical clone. Shallow, promisor, partial, missing, or ambiguous canonical graphs stay protected.
+   - Review the manifest, then dry-run it:
+     `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json`
+   - Apply only the unchanged manifest:
+     `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json --apply`
+   - Apply revalidates host, project snapshot, names, roots, sizes, canonical mapping, clone health, SQLite integrity, and holders before each deletion. Held databases are skipped. Unmapped live roots, missing or unhealthy canonical graphs, corrupt databases, drift, or deletion failures stop the host.
+   - Deletion uses `codebase-memory-mcp cli delete_project` only. Never remove project databases directly.
+8. Report exact proof.
    - Indexed project name.
    - Node and edge counts when available.
    - UI URL and tmux session name.
+   - For cleanup: manifest path and digest, before/after project and byte totals, deleted project names, protected/skipped reasons, and any stop condition.
    - Missing binaries, unavailable MCP tools, or incomplete proof.
 
 ## Inputs
@@ -50,9 +69,11 @@ Bring up `codebase-memory-mcp` for a repository and prove the graph is usable be
 - Repository path.
 - Index mode: `fast`, `moderate`, `full`, or `cross-repo-intelligence`.
 - Optional UI port; default `9749`.
+- For cache maintenance: a host-local manifest path and optional explicit ephemeral prefixes.
 
 ## Outputs
 
 - Indexed and queryable repository graph.
 - Verified local graph UI when requested.
+- A dry-run cache manifest or guarded CLI-only deletion report.
 - Exact status, schema, and proof summary.

--- a/skills/codebase-memory-mcp/agents/openai.yaml
+++ b/skills/codebase-memory-mcp/agents/openai.yaml
@@ -1,10 +1,10 @@
 interface:
   display_name: "Codebase Memory MCP"
-  short_description: "Index repositories and verify graph-backed code discovery."
+  short_description: "Index canonical checkouts and audit duplicate worktree graphs."
   icon_small: "./assets/icon.jpg"
   icon_large: "./assets/icon.jpg"
   brand_color: "#111827"
-  default_prompt: "Index this repository with codebase-memory-mcp, verify the graph and UI, then use graph tools for focused code discovery."
+  default_prompt: "Resolve linked worktrees to their canonical owning checkout before indexing. Audit cache with a reviewed manifest; prune through the CLI only."
 
 policy:
   allow_implicit_invocation: true

--- a/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
+++ b/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
@@ -8,22 +8,38 @@ Usage: codebase-memory-graph.sh <command> [options]
 Commands:
   init       Configure UI, index the repo, start UI, and run a schema smoke check
   index      Index the repo
+  canonical  Print the canonical owning checkout used for indexing
   start-ui   Start the tmux keepalive that exposes the HTTP graph UI
   stop-ui    Stop the tmux keepalive session for the repo
   status     Show config, projects, and UI listener state
   schema     Print graph schema for the repo's indexed project
+  cache-audit
+             Write a guarded duplicate/dead-root cache manifest without deleting
+  cache-prune
+             Validate a cache manifest; add --apply to delete through the CLI
   keepalive  Internal command used inside tmux
 
 Options:
   --repo PATH     Repository root. Defaults to git root or current directory.
   --mode MODE     Index mode: fast, moderate, full, cross-repo-intelligence. Default: full.
   --port PORT     UI port. Default: 9749.
+  --manifest PATH Required for cache-audit and cache-prune.
+  --ephemeral-prefix PATH
+                  Allow missing-root deletion candidates below this explicit prefix.
+                  Repeat for more than one prefix.
+  --cache-dir PATH
+                  Override the codebase-memory-mcp cache root.
+  --apply         Execute cache-prune. Without it, cache-prune is a dry run.
 EOF
 }
 
 repo=""
 mode="full"
 port="9749"
+manifest=""
+cache_dir=""
+apply="false"
+ephemeral_prefixes=()
 command="${1:-}"
 [[ -n "$command" ]] && shift || true
 
@@ -40,6 +56,22 @@ while [[ $# -gt 0 ]]; do
     --port)
       port="${2:?--port requires a value}"
       shift 2
+      ;;
+    --manifest)
+      manifest="${2:?--manifest requires a path}"
+      shift 2
+      ;;
+    --ephemeral-prefix)
+      ephemeral_prefixes+=("${2:?--ephemeral-prefix requires a path}")
+      shift 2
+      ;;
+    --cache-dir)
+      cache_dir="${2:?--cache-dir requires a path}"
+      shift 2
+      ;;
+    --apply)
+      apply="true"
+      shift
       ;;
     -h|--help)
       usage
@@ -65,13 +97,27 @@ need() {
   }
 }
 
+cache_helper() {
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  printf '%s/codebase_memory_cache.py\n' "$script_dir"
+}
+
 resolve_repo() {
-  if [[ -n "$repo" ]]; then
-    cd "$repo"
-    pwd
-    return
+  local requested resolved
+  need git
+  need python3
+  requested="$repo"
+  if [[ -z "$requested" ]]; then
+    requested="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   fi
-  git rev-parse --show-toplevel 2>/dev/null || pwd
+  resolved="$(python3 "$(cache_helper)" resolve "$requested")"
+  RESOLVED_JSON="$resolved" python3 - <<'PY'
+import json
+import os
+
+print(json.loads(os.environ["RESOLVED_JSON"])["canonical_root"])
+PY
 }
 
 json_index_payload() {
@@ -187,6 +233,53 @@ cmd_index() {
   codebase-memory-mcp cli index_repository "$payload"
 }
 
+cmd_canonical() {
+  local root
+  root="$(resolve_repo)"
+  printf 'repo=%s\n' "$root"
+}
+
+cmd_cache_audit() {
+  local helper args
+  need codebase-memory-mcp
+  need python3
+  [[ -n "$manifest" ]] || {
+    printf 'cache-audit requires --manifest PATH\n' >&2
+    exit 2
+  }
+  [[ "$apply" == "false" ]] || {
+    printf -- '--apply is valid only with cache-prune\n' >&2
+    exit 2
+  }
+  helper="$(cache_helper)"
+  args=(audit --manifest "$manifest")
+  [[ -z "$cache_dir" ]] || args+=(--cache-dir "$cache_dir")
+  local prefix
+  for prefix in "${ephemeral_prefixes[@]}"; do
+    args+=(--ephemeral-prefix "$prefix")
+  done
+  python3 "$helper" "${args[@]}"
+}
+
+cmd_cache_prune() {
+  local helper args
+  need codebase-memory-mcp
+  need python3
+  [[ -n "$manifest" ]] || {
+    printf 'cache-prune requires --manifest PATH\n' >&2
+    exit 2
+  }
+  ((${#ephemeral_prefixes[@]} == 0)) || {
+    printf -- '--ephemeral-prefix belongs on cache-audit only\n' >&2
+    exit 2
+  }
+  helper="$(cache_helper)"
+  args=(prune --manifest "$manifest")
+  [[ -z "$cache_dir" ]] || args+=(--cache-dir "$cache_dir")
+  [[ "$apply" == "false" ]] || args+=(--apply)
+  python3 "$helper" "${args[@]}"
+}
+
 cmd_start_ui() {
   local root session script keepalive_cmd
   need codebase-memory-mcp
@@ -258,10 +351,13 @@ cmd_init() {
 case "$command" in
   init) cmd_init ;;
   index) cmd_index ;;
+  canonical) cmd_canonical ;;
   start-ui) cmd_start_ui ;;
   stop-ui) cmd_stop_ui ;;
   status) cmd_status ;;
   schema) cmd_schema ;;
+  cache-audit) cmd_cache_audit ;;
+  cache-prune) cmd_cache_prune ;;
   keepalive) cmd_keepalive ;;
   -h|--help|"") usage ;;
   *)

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -1,0 +1,716 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import socket
+import sqlite3
+import subprocess
+import sys
+import urllib.parse
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+HOST_BLOCKING_REASONS = {
+    "canonical_clone_not_full",
+    "empty_root",
+    "live_root_unmapped",
+    "missing_canonical_graph",
+}
+
+
+class SafetyError(RuntimeError):
+    pass
+
+
+def run(
+    command: list[str],
+    *,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise SafetyError(f"{' '.join(command[:3])}: {detail}")
+    return result
+
+
+def git_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for name in (
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_WORK_TREE",
+    ):
+        env.pop(name, None)
+    return env
+
+
+def git(path: pathlib.Path, *args: str) -> str:
+    return run(["git", "-C", str(path), *args], env=git_env()).stdout.strip()
+
+
+def absolute_git_path(root: pathlib.Path, option: str) -> pathlib.Path:
+    result = run(
+        ["git", "-C", str(root), "rev-parse", "--path-format=absolute", option],
+        check=False,
+        env=git_env(),
+    )
+    if result.returncode == 0:
+        return pathlib.Path(result.stdout.strip()).resolve()
+    value = git(root, "rev-parse", option)
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        path = root / path
+    return path.resolve()
+
+
+def worktree_paths(root: pathlib.Path) -> list[pathlib.Path]:
+    result = run(
+        ["git", "-C", str(root), "worktree", "list", "--porcelain", "-z"],
+        env=git_env(),
+    )
+    paths: list[pathlib.Path] = []
+    for field in result.stdout.split("\0"):
+        if field.startswith("worktree "):
+            paths.append(pathlib.Path(field.removeprefix("worktree ")).resolve())
+    return paths
+
+
+def clone_health(root: pathlib.Path) -> dict[str, Any]:
+    shallow = git(root, "rev-parse", "--is-shallow-repository") == "true"
+    promisor = (
+        run(
+            ["git", "-C", str(root), "config", "--bool", "--get", "remote.origin.promisor"],
+            check=False,
+            env=git_env(),
+        ).stdout.strip()
+        == "true"
+    )
+    partial_filter = run(
+        ["git", "-C", str(root), "config", "--get", "remote.origin.partialclonefilter"],
+        check=False,
+        env=git_env(),
+    ).stdout.strip()
+    return {
+        "shallow": shallow,
+        "promisor": promisor,
+        "partial_filter": partial_filter,
+        "full": not shallow and not promisor and not partial_filter,
+    }
+
+
+def resolve_repository(path: str | os.PathLike[str]) -> dict[str, Any]:
+    requested = pathlib.Path(path).expanduser()
+    if not requested.exists() or not requested.is_dir():
+        raise SafetyError(f"repository path is missing or not a directory: {requested}")
+    requested = requested.resolve()
+    if git(requested, "rev-parse", "--is-inside-work-tree") != "true":
+        raise SafetyError(f"not a Git worktree: {requested}")
+    if git(requested, "rev-parse", "--is-bare-repository") == "true":
+        raise SafetyError(f"bare repositories are not indexable: {requested}")
+
+    root = pathlib.Path(git(requested, "rev-parse", "--show-toplevel")).resolve()
+    common_dir = absolute_git_path(root, "--git-common-dir")
+    git_dir = absolute_git_path(root, "--git-dir")
+    canonical = root
+
+    if git_dir != common_dir:
+        owners: list[pathlib.Path] = []
+        for candidate in worktree_paths(root):
+            if not candidate.is_dir():
+                continue
+            try:
+                candidate_root = pathlib.Path(
+                    git(candidate, "rev-parse", "--show-toplevel")
+                ).resolve()
+                candidate_git_dir = absolute_git_path(candidate_root, "--git-dir")
+                candidate_common_dir = absolute_git_path(
+                    candidate_root, "--git-common-dir"
+                )
+            except SafetyError:
+                continue
+            if candidate_git_dir == common_dir and candidate_common_dir == common_dir:
+                owners.append(candidate_root)
+        owners = sorted(set(owners))
+        if len(owners) != 1:
+            raise SafetyError(
+                f"cannot identify one owning checkout for Git common dir {common_dir}"
+            )
+        canonical = owners[0]
+
+    if not canonical.is_dir():
+        raise SafetyError(f"owning checkout is missing: {canonical}")
+    if git(canonical, "rev-parse", "--is-inside-work-tree") != "true":
+        raise SafetyError(f"owning checkout is not a Git worktree: {canonical}")
+    if absolute_git_path(canonical, "--git-common-dir") != common_dir:
+        raise SafetyError(f"owning checkout changed Git common dir: {canonical}")
+    if absolute_git_path(canonical, "--git-dir") != common_dir:
+        raise SafetyError(f"owning checkout does not own Git common dir: {canonical}")
+
+    return {
+        "requested": str(requested),
+        "root": str(root),
+        "canonical_root": str(canonical),
+        "common_dir": str(common_dir),
+        "git_dir": str(git_dir),
+        "linked_worktree": root != canonical,
+        "clone": clone_health(canonical),
+    }
+
+
+def cbm_cache_dir(value: str | None) -> pathlib.Path:
+    if value:
+        return pathlib.Path(value).expanduser().resolve()
+    if os.environ.get("CBM_CACHE_DIR"):
+        return pathlib.Path(os.environ["CBM_CACHE_DIR"]).expanduser().resolve()
+    base = pathlib.Path(os.environ.get("XDG_CACHE_HOME", pathlib.Path.home() / ".cache"))
+    return (base / "codebase-memory-mcp").resolve()
+
+
+def cbm_binary(value: str | None) -> str:
+    candidate = value or shutil.which("codebase-memory-mcp")
+    if not candidate:
+        raise SafetyError("missing required command: codebase-memory-mcp")
+    return candidate
+
+
+def list_projects(binary: str) -> list[dict[str, Any]]:
+    result = run([binary, "cli", "list_projects"])
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise SafetyError(f"list_projects returned invalid JSON: {error}") from error
+    projects = payload.get("projects")
+    if not isinstance(projects, list):
+        raise SafetyError("list_projects response has no projects array")
+    normalized: list[dict[str, Any]] = []
+    names: set[str] = set()
+    for project in projects:
+        if not isinstance(project, dict):
+            raise SafetyError("list_projects returned a non-object project")
+        name = project.get("name")
+        root_path = project.get("root_path")
+        size_bytes = project.get("size_bytes")
+        if (
+            not isinstance(name, str)
+            or not name
+            or "/" in name
+            or "\0" in name
+            or not isinstance(root_path, str)
+            or not isinstance(size_bytes, int)
+            or size_bytes < 0
+        ):
+            raise SafetyError(f"invalid project record: {project!r}")
+        if name in names:
+            raise SafetyError(f"duplicate project name: {name}")
+        names.add(name)
+        normalized.append(
+            {
+                "name": name,
+                "root_path": root_path,
+                "size_bytes": size_bytes,
+                "nodes": project.get("nodes"),
+                "edges": project.get("edges"),
+            }
+        )
+    return sorted(normalized, key=lambda item: item["name"])
+
+
+def project_snapshot(projects: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": project["name"],
+            "root_path": project["root_path"],
+            "size_bytes": project["size_bytes"],
+        }
+        for project in projects
+    ]
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+
+
+def manifest_digest(payload: dict[str, Any]) -> str:
+    unsigned = dict(payload)
+    unsigned.pop("manifest_digest", None)
+    return hashlib.sha256(canonical_json(unsigned)).hexdigest()
+
+
+def normalize_prefix(
+    raw: str, *, cache_dir: pathlib.Path, home: pathlib.Path
+) -> pathlib.Path:
+    prefix = pathlib.Path(raw).expanduser()
+    if not prefix.is_absolute():
+        raise SafetyError(f"ephemeral prefix must be absolute: {raw}")
+    prefix = prefix.resolve()
+    forbidden = {pathlib.Path("/"), home.resolve(), cache_dir.resolve()}
+    if prefix in forbidden:
+        raise SafetyError(f"unsafe ephemeral prefix: {prefix}")
+    return prefix
+
+
+def path_is_under(path: pathlib.Path, prefix: pathlib.Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(prefix.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def project_for_root(
+    projects: list[dict[str, Any]], root: pathlib.Path
+) -> dict[str, Any] | None:
+    matches = []
+    for project in projects:
+        raw = project["root_path"]
+        if not raw:
+            continue
+        try:
+            candidate = pathlib.Path(raw).expanduser().resolve(strict=False)
+        except OSError:
+            continue
+        if candidate == root:
+            matches.append(project)
+    if len(matches) > 1:
+        raise SafetyError(f"multiple projects map to canonical root: {root}")
+    return matches[0] if matches else None
+
+
+def build_manifest(
+    *,
+    projects: list[dict[str, Any]],
+    cache_dir: pathlib.Path,
+    ephemeral_prefixes: list[pathlib.Path],
+) -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
+    protected: list[dict[str, Any]] = []
+    for project in projects:
+        raw_root = project["root_path"]
+        base = {
+            "name": project["name"],
+            "root_path": raw_root,
+            "size_bytes": project["size_bytes"],
+        }
+        if not raw_root:
+            protected.append({**base, "reason": "empty_root"})
+            continue
+        root = pathlib.Path(raw_root).expanduser()
+        if not root.exists():
+            normalized = root.resolve(strict=False)
+            matching_prefix = next(
+                (
+                    prefix
+                    for prefix in ephemeral_prefixes
+                    if path_is_under(normalized, prefix)
+                ),
+                None,
+            )
+            if matching_prefix is None:
+                protected.append({**base, "reason": "missing_root_outside_prefix"})
+            else:
+                candidates.append(
+                    {
+                        **base,
+                        "reason": "ephemeral_missing_root",
+                        "ephemeral_prefix": str(matching_prefix),
+                    }
+                )
+            continue
+        try:
+            resolved = resolve_repository(root)
+        except SafetyError as error:
+            protected.append(
+                {**base, "reason": "live_root_unmapped", "detail": str(error)}
+            )
+            continue
+        canonical_root = pathlib.Path(resolved["canonical_root"])
+        if pathlib.Path(resolved["root"]) == canonical_root:
+            protected.append({**base, "reason": "canonical_root"})
+            continue
+        canonical_project = project_for_root(projects, canonical_root)
+        if canonical_project is None:
+            protected.append(
+                {
+                    **base,
+                    "reason": "missing_canonical_graph",
+                    "canonical_root": str(canonical_root),
+                }
+            )
+            continue
+        if not resolved["clone"]["full"]:
+            protected.append(
+                {
+                    **base,
+                    "reason": "canonical_clone_not_full",
+                    "canonical_root": str(canonical_root),
+                    "canonical_project": canonical_project["name"],
+                }
+            )
+            continue
+        candidates.append(
+            {
+                **base,
+                "reason": "linked_worktree_duplicate",
+                "canonical_root": str(canonical_root),
+                "canonical_project": canonical_project["name"],
+                "canonical_project_root_path": canonical_project["root_path"],
+                "canonical_size_bytes": canonical_project["size_bytes"],
+                "common_dir": resolved["common_dir"],
+            }
+        )
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "host": socket.gethostname(),
+        "cache_dir": str(cache_dir),
+        "ephemeral_prefixes": [str(prefix) for prefix in ephemeral_prefixes],
+        "snapshot": project_snapshot(projects),
+        "project_bytes": sum(project["size_bytes"] for project in projects),
+        "candidates": candidates,
+        "protected": protected,
+        "blockers": [
+            item for item in protected if item["reason"] in HOST_BLOCKING_REASONS
+        ],
+    }
+    payload["manifest_digest"] = manifest_digest(payload)
+    return payload
+
+
+def write_manifest(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, path)
+
+
+def load_manifest(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise SafetyError(f"cannot read manifest {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise SafetyError("manifest must be a JSON object")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise SafetyError("unsupported manifest schema")
+    if payload.get("manifest_digest") != manifest_digest(payload):
+        raise SafetyError("manifest digest mismatch")
+    if payload.get("host") != socket.gethostname():
+        raise SafetyError(
+            f"manifest host mismatch: {payload.get('host')} != {socket.gethostname()}"
+        )
+    return payload
+
+
+def validate_snapshot(
+    expected: list[dict[str, Any]], projects: list[dict[str, Any]]
+) -> None:
+    if expected != project_snapshot(projects):
+        raise SafetyError("project manifest drift detected")
+
+
+def db_path(cache_dir: pathlib.Path, project_name: str) -> pathlib.Path:
+    if (
+        not project_name
+        or project_name in {".", ".."}
+        or "/" in project_name
+        or "\0" in project_name
+    ):
+        raise SafetyError(f"unsafe project name: {project_name!r}")
+    path = cache_dir / f"{project_name}.db"
+    if path.parent.resolve() != cache_dir.resolve():
+        raise SafetyError(f"project DB escapes cache root: {path}")
+    return path
+
+
+def db_is_held(path: pathlib.Path) -> bool:
+    lsof = shutil.which("lsof")
+    if not lsof:
+        raise SafetyError("lsof is required for cache pruning")
+    paths = [path, pathlib.Path(f"{path}-wal"), pathlib.Path(f"{path}-shm")]
+    existing = [str(candidate) for candidate in paths if candidate.exists()]
+    if not existing:
+        return False
+    result = run([lsof, "-F", "p", "--", *existing], check=False)
+    if result.returncode not in (0, 1):
+        raise SafetyError(f"lsof failed for {path}: {result.stderr.strip()}")
+    return bool(result.stdout.strip())
+
+
+def validate_database(path: pathlib.Path, expected_size: int) -> None:
+    if not path.is_file() or path.is_symlink():
+        raise SafetyError(f"project DB is missing, non-regular, or symlinked: {path}")
+    actual_size = path.stat().st_size
+    if actual_size != expected_size:
+        raise SafetyError(
+            f"project DB size changed for {path.name}: {actual_size} != {expected_size}"
+        )
+    try:
+        encoded_path = urllib.parse.quote(str(path), safe="/")
+        connection = sqlite3.connect(f"file:{encoded_path}?mode=ro", uri=True)
+        try:
+            row = connection.execute("PRAGMA quick_check").fetchone()
+        finally:
+            connection.close()
+    except sqlite3.DatabaseError as error:
+        raise SafetyError(f"project DB is corrupt: {path}: {error}") from error
+    if not row or row[0] != "ok":
+        raise SafetyError(f"project DB quick_check failed: {path}: {row}")
+
+
+def revalidate_candidate(
+    candidate: dict[str, Any],
+    projects: list[dict[str, Any]],
+    prefixes: list[pathlib.Path],
+) -> None:
+    current = next(
+        (project for project in projects if project["name"] == candidate["name"]),
+        None,
+    )
+    if current is None:
+        raise SafetyError(f"candidate disappeared: {candidate['name']}")
+    for field in ("root_path", "size_bytes"):
+        if current[field] != candidate[field]:
+            raise SafetyError(f"candidate {field} changed: {candidate['name']}")
+
+    root = pathlib.Path(candidate["root_path"]).expanduser()
+    reason = candidate["reason"]
+    if reason == "ephemeral_missing_root":
+        if root.exists():
+            raise SafetyError(f"ephemeral root became live: {root}")
+        expected_prefix = pathlib.Path(candidate["ephemeral_prefix"])
+        if expected_prefix not in prefixes or not path_is_under(root, expected_prefix):
+            raise SafetyError(f"ephemeral prefix guard failed: {root}")
+        return
+    if reason != "linked_worktree_duplicate":
+        raise SafetyError(f"unsupported candidate reason: {reason}")
+
+    resolved = resolve_repository(root)
+    if resolved["root"] != str(root.resolve()):
+        raise SafetyError(f"candidate root changed: {root}")
+    if resolved["canonical_root"] != candidate["canonical_root"]:
+        raise SafetyError(f"candidate canonical root changed: {root}")
+    if resolved["common_dir"] != candidate["common_dir"]:
+        raise SafetyError(f"candidate Git common dir changed: {root}")
+    if not resolved["linked_worktree"]:
+        raise SafetyError(f"candidate is no longer a linked worktree: {root}")
+    if not resolved["clone"]["full"]:
+        raise SafetyError(f"candidate canonical clone is not full: {root}")
+    canonical = next(
+        (
+            project
+            for project in projects
+            if project["name"] == candidate["canonical_project"]
+        ),
+        None,
+    )
+    if canonical is None:
+        raise SafetyError(f"canonical graph disappeared: {candidate['canonical_project']}")
+    if canonical["root_path"] != candidate["canonical_project_root_path"]:
+        raise SafetyError(f"canonical graph registration changed: {candidate['canonical_project']}")
+    if (
+        pathlib.Path(canonical["root_path"]).expanduser().resolve()
+        != pathlib.Path(candidate["canonical_root"])
+    ):
+        raise SafetyError(f"canonical graph root changed: {candidate['canonical_project']}")
+    if canonical["size_bytes"] != candidate["canonical_size_bytes"]:
+        raise SafetyError(f"canonical graph size changed: {candidate['canonical_project']}")
+
+
+def delete_project(binary: str, project_name: str) -> None:
+    payload = json.dumps({"project": project_name}, separators=(",", ":"))
+    result = run([binary, "cli", "delete_project", payload], check=False)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown failure"
+        raise SafetyError(f"delete_project failed for {project_name}: {detail}")
+
+
+def audit(args: argparse.Namespace) -> int:
+    binary = cbm_binary(args.cbm_bin)
+    cache_dir = cbm_cache_dir(args.cache_dir)
+    home = pathlib.Path.home().resolve()
+    prefixes = sorted(
+        {
+            normalize_prefix(value, cache_dir=cache_dir, home=home)
+            for value in args.ephemeral_prefix
+        }
+    )
+    projects = list_projects(binary)
+    payload = build_manifest(
+        projects=projects,
+        cache_dir=cache_dir,
+        ephemeral_prefixes=prefixes,
+    )
+    manifest_path = pathlib.Path(args.manifest).expanduser().resolve()
+    write_manifest(manifest_path, payload)
+    print(
+        json.dumps(
+            {
+                "action": "audit",
+                "manifest": str(manifest_path),
+                "projects": len(projects),
+                "project_bytes": payload["project_bytes"],
+                "candidates": len(payload["candidates"]),
+                "protected": len(payload["protected"]),
+                "blockers": len(payload["blockers"]),
+                "candidate_bytes": sum(
+                    item["size_bytes"] for item in payload["candidates"]
+                ),
+                "applied": False,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def prune(args: argparse.Namespace) -> int:
+    manifest_path = pathlib.Path(args.manifest).expanduser().resolve()
+    payload = load_manifest(manifest_path)
+    binary = cbm_binary(args.cbm_bin)
+    cache_dir = cbm_cache_dir(args.cache_dir)
+    if str(cache_dir) != payload.get("cache_dir"):
+        raise SafetyError(
+            f"cache root mismatch: {cache_dir} != {payload.get('cache_dir')}"
+        )
+    prefixes = [pathlib.Path(value) for value in payload["ephemeral_prefixes"]]
+    projects = list_projects(binary)
+    validate_snapshot(payload["snapshot"], projects)
+    if payload.get("blockers"):
+        reasons = sorted({item["reason"] for item in payload["blockers"]})
+        raise SafetyError(
+            "host cache manifest is blocked: " + ", ".join(reasons)
+        )
+
+    if not args.apply:
+        print(
+            json.dumps(
+                {
+                    "action": "prune",
+                    "manifest": str(manifest_path),
+                    "candidates": len(payload["candidates"]),
+                    "candidate_bytes": sum(
+                        item["size_bytes"] for item in payload["candidates"]
+                    ),
+                    "projects": len(projects),
+                    "project_bytes": sum(
+                        project["size_bytes"] for project in projects
+                    ),
+                    "applied": False,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    expected_snapshot = list(payload["snapshot"])
+    before_projects = len(projects)
+    before_bytes = sum(project["size_bytes"] for project in projects)
+    deleted: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for candidate in payload["candidates"]:
+        projects = list_projects(binary)
+        validate_snapshot(expected_snapshot, projects)
+        revalidate_candidate(candidate, projects, prefixes)
+        path = db_path(cache_dir, candidate["name"])
+        if db_is_held(path):
+            skipped.append({"name": candidate["name"], "reason": "held"})
+            continue
+        validate_database(path, candidate["size_bytes"])
+        delete_project(binary, candidate["name"])
+        projects = list_projects(binary)
+        expected_snapshot = [
+            item
+            for item in expected_snapshot
+            if item["name"] != candidate["name"]
+        ]
+        validate_snapshot(expected_snapshot, projects)
+        deleted.append(
+            {
+                "name": candidate["name"],
+                "bytes": candidate["size_bytes"],
+                "reason": candidate["reason"],
+            }
+        )
+
+    print(
+        json.dumps(
+            {
+                "action": "prune",
+                "manifest": str(manifest_path),
+                "applied": True,
+                "deleted": deleted,
+                "deleted_bytes": sum(item["bytes"] for item in deleted),
+                "skipped": skipped,
+                "before_projects": before_projects,
+                "before_bytes": before_bytes,
+                "after_projects": len(projects),
+                "after_bytes": sum(
+                    project["size_bytes"] for project in projects
+                ),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    subparsers = root.add_subparsers(dest="command", required=True)
+
+    resolve = subparsers.add_parser("resolve")
+    resolve.add_argument("repo")
+
+    audit_parser = subparsers.add_parser("audit")
+    audit_parser.add_argument("--manifest", required=True)
+    audit_parser.add_argument("--ephemeral-prefix", action="append", default=[])
+    audit_parser.add_argument("--cache-dir")
+    audit_parser.add_argument("--cbm-bin")
+
+    prune_parser = subparsers.add_parser("prune")
+    prune_parser.add_argument("--manifest", required=True)
+    prune_parser.add_argument("--cache-dir")
+    prune_parser.add_argument("--cbm-bin")
+    prune_parser.add_argument("--apply", action="store_true")
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        if args.command == "resolve":
+            print(json.dumps(resolve_repository(args.repo), sort_keys=True))
+            return 0
+        if args.command == "audit":
+            return audit(args)
+        if args.command == "prune":
+            return prune(args)
+    except SafetyError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import pathlib
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = (
+    ROOT
+    / "skills"
+    / "codebase-memory-mcp"
+    / "scripts"
+    / "codebase_memory_cache.py"
+)
+SCRIPT = (
+    ROOT
+    / "skills"
+    / "codebase-memory-mcp"
+    / "scripts"
+    / "codebase-memory-graph.sh"
+)
+
+SPEC = importlib.util.spec_from_file_location("codebase_memory_cache", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load {MODULE_PATH}")
+CBM = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CBM)
+
+
+def command(*args: str, cwd: pathlib.Path | None = None) -> str:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def init_repo(path: pathlib.Path) -> None:
+    path.mkdir()
+    command("git", "init", "-q", "-b", "main", str(path))
+    command("git", "-C", str(path), "config", "user.name", "Test User")
+    command("git", "-C", str(path), "config", "user.email", "test@example.test")
+    (path / "README.md").write_text("fixture\n")
+    command("git", "-C", str(path), "add", "README.md")
+    command("git", "-C", str(path), "commit", "-qm", "test: fixture")
+
+
+def sqlite_file(path: pathlib.Path) -> int:
+    connection = sqlite3.connect(path)
+    connection.execute("CREATE TABLE proof (value TEXT)")
+    connection.commit()
+    connection.close()
+    return path.stat().st_size
+
+
+class ResolverTests(unittest.TestCase):
+    def test_main_and_linked_worktree_resolve_to_same_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            main = temp / "main"
+            worktree = temp / "branch"
+            init_repo(main)
+            command(
+                "git",
+                "-C",
+                str(main),
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "feature",
+                str(worktree),
+            )
+            main_result = CBM.resolve_repository(main)
+            worktree_result = CBM.resolve_repository(worktree)
+            self.assertEqual(main_result["canonical_root"], str(main.resolve()))
+            self.assertEqual(worktree_result["canonical_root"], str(main.resolve()))
+            self.assertFalse(main_result["linked_worktree"])
+            self.assertTrue(worktree_result["linked_worktree"])
+
+    def test_separate_clones_remain_distinct(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            first = temp / "first"
+            second = temp / "second"
+            init_repo(first)
+            command("git", "clone", "-q", str(first), str(second))
+            self.assertNotEqual(
+                CBM.resolve_repository(first)["canonical_root"],
+                CBM.resolve_repository(second)["canonical_root"],
+            )
+
+    def test_symlink_is_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            repo = temp / "repo"
+            alias = temp / "alias"
+            init_repo(repo)
+            alias.symlink_to(repo, target_is_directory=True)
+            self.assertEqual(
+                CBM.resolve_repository(alias)["canonical_root"], str(repo.resolve())
+            )
+
+    def test_missing_bare_and_invalid_paths_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            bare = temp / "bare.git"
+            invalid = temp / "invalid"
+            invalid.mkdir()
+            command("git", "init", "-q", "--bare", str(bare))
+            for path in (temp / "missing", bare, invalid):
+                with self.subTest(path=path):
+                    with self.assertRaises(CBM.SafetyError):
+                        CBM.resolve_repository(path)
+
+
+class CacheManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.temp = pathlib.Path(self.temporary.name)
+        self.main = self.temp / "main"
+        self.worktree = self.temp / "worktree"
+        self.cache = self.temp / "cache"
+        self.state = self.temp / "projects.json"
+        self.deleted = self.temp / "deleted.jsonl"
+        self.manifest = self.temp / "manifest.json"
+        self.bin = self.temp / "bin"
+        self.bin.mkdir()
+        self.cache.mkdir()
+        init_repo(self.main)
+        command(
+            "git",
+            "-C",
+            str(self.main),
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "feature",
+            str(self.worktree),
+        )
+        self.main_name = "fixture-main"
+        self.worktree_name = "fixture-worktree"
+        main_size = sqlite_file(self.cache / f"{self.main_name}.db")
+        worktree_size = sqlite_file(self.cache / f"{self.worktree_name}.db")
+        self.projects = [
+            {
+                "name": self.main_name,
+                "root_path": str(self.main),
+                "size_bytes": main_size,
+                "nodes": 1,
+                "edges": 1,
+            },
+            {
+                "name": self.worktree_name,
+                "root_path": str(self.worktree),
+                "size_bytes": worktree_size,
+                "nodes": 1,
+                "edges": 1,
+            },
+        ]
+        self.write_projects(self.projects)
+        fake_cbm = self.bin / "codebase-memory-mcp"
+        fake_cbm.write_text(
+            """#!/usr/bin/env python3
+import json, os, pathlib, sys
+state = pathlib.Path(os.environ["FAKE_CBM_STATE"])
+payload = json.loads(state.read_text())
+if sys.argv[1:3] == ["cli", "list_projects"]:
+    print(json.dumps({"projects": payload}))
+    raise SystemExit(0)
+if sys.argv[1:3] == ["cli", "delete_project"]:
+    name = json.loads(sys.argv[3])["project"]
+    deleted = pathlib.Path(os.environ["FAKE_CBM_DELETED"])
+    with deleted.open("a") as handle:
+        handle.write(json.dumps({"project": name}) + "\\n")
+    state.write_text(json.dumps([item for item in payload if item["name"] != name]))
+    raise SystemExit(0)
+raise SystemExit(2)
+"""
+        )
+        fake_cbm.chmod(0o755)
+        fake_lsof = self.bin / "lsof"
+        fake_lsof.write_text(
+            '#!/bin/sh\n'
+            'status="${FAKE_LSOF_STATUS:-1}"\n'
+            '[ "$status" -ne 0 ] || printf "p123\\n"\n'
+            'exit "$status"\n'
+        )
+        fake_lsof.chmod(0o755)
+        self.environment = {
+            **os.environ,
+            "PATH": f"{self.bin}:{os.environ['PATH']}",
+            "FAKE_CBM_STATE": str(self.state),
+            "FAKE_CBM_DELETED": str(self.deleted),
+            "CBM_CACHE_DIR": str(self.cache),
+        }
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_projects(self, projects: list[dict[str, object]]) -> None:
+        self.state.write_text(json.dumps(projects))
+
+    def run_script(
+        self, *args: str, check: bool = True, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(SCRIPT), *args],
+            check=check,
+            capture_output=True,
+            text=True,
+            env=env or self.environment,
+        )
+
+    def audit(self, *extra: str) -> None:
+        self.run_script(
+            "cache-audit",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            *extra,
+        )
+
+    def apply(self, *, check: bool = True, env: dict[str, str] | None = None):
+        return self.run_script(
+            "cache-prune",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            "--apply",
+            check=check,
+            env=env,
+        )
+
+    def test_prune_is_dry_run_by_default(self) -> None:
+        self.audit()
+        result = self.run_script(
+            "cache-prune",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+        )
+        self.assertFalse(self.deleted.exists())
+        self.assertFalse(json.loads(result.stdout)["applied"])
+
+    def test_unchanged_manifest_applies_through_delete_project(self) -> None:
+        self.audit()
+        result = self.apply()
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["deleted"][0]["name"], self.worktree_name)
+        self.assertEqual(
+            json.loads(self.deleted.read_text().strip())["project"],
+            self.worktree_name,
+        )
+        remaining = json.loads(self.state.read_text())
+        self.assertEqual([item["name"] for item in remaining], [self.main_name])
+
+    def test_modified_manifest_is_rejected(self) -> None:
+        self.audit()
+        payload = json.loads(self.manifest.read_text())
+        payload["candidates"][0]["size_bytes"] += 1
+        self.manifest.write_text(json.dumps(payload))
+        result = self.apply(check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("manifest digest mismatch", result.stderr)
+
+    def test_held_database_is_skipped(self) -> None:
+        self.audit()
+        environment = {**self.environment, "FAKE_LSOF_STATUS": "0"}
+        result = self.apply(env=environment)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["skipped"], [{"name": self.worktree_name, "reason": "held"}]
+        )
+        self.assertFalse(self.deleted.exists())
+
+    def test_corrupt_database_stops_apply(self) -> None:
+        corrupt = self.cache / f"{self.worktree_name}.db"
+        size = corrupt.stat().st_size
+        corrupt.write_bytes(b"x" * size)
+        self.audit()
+        result = self.apply(check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("corrupt", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_project_snapshot_change_stops_apply(self) -> None:
+        self.audit()
+        changed = json.loads(self.state.read_text())
+        changed[1]["size_bytes"] += 1
+        self.write_projects(changed)
+        result = self.apply(check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("manifest drift", result.stderr)
+
+    def test_missing_live_root_and_canonical_root_stop_apply(self) -> None:
+        for removed in ("worktree", "main"):
+            with self.subTest(removed=removed):
+                self.audit()
+                target = self.worktree if removed == "worktree" else self.main
+                renamed = target.with_name(f"{target.name}.moved")
+                target.rename(renamed)
+                try:
+                    result = self.apply(check=False)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertFalse(self.deleted.exists())
+                finally:
+                    renamed.rename(target)
+
+    def test_ephemeral_prefix_guards_missing_roots(self) -> None:
+        missing = self.temp / "ephemeral" / "gone"
+        name = "fixture-ephemeral"
+        size = sqlite_file(self.cache / f"{name}.db")
+        self.projects.append(
+            {
+                "name": name,
+                "root_path": str(missing),
+                "size_bytes": size,
+                "nodes": 1,
+                "edges": 1,
+            }
+        )
+        self.write_projects(self.projects)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        payload = json.loads(self.manifest.read_text())
+        self.assertIn(name, [item["name"] for item in payload["candidates"]])
+
+        unsafe = self.run_script(
+            "cache-audit",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            "--ephemeral-prefix",
+            "/",
+            check=False,
+        )
+        self.assertNotEqual(unsafe.returncode, 0)
+        self.assertIn("unsafe ephemeral prefix", unsafe.stderr)
+
+    def test_unmapped_live_root_blocks_the_host(self) -> None:
+        invalid_root = self.temp / "invalid-live-root"
+        invalid_root.mkdir()
+        name = "fixture-invalid"
+        size = sqlite_file(self.cache / f"{name}.db")
+        self.projects.append(
+            {
+                "name": name,
+                "root_path": str(invalid_root),
+                "size_bytes": size,
+                "nodes": 1,
+                "edges": 1,
+            }
+        )
+        self.write_projects(self.projects)
+        self.audit()
+        result = self.run_script(
+            "cache-prune",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("host cache manifest is blocked", result.stderr)
+
+    def test_manifest_digest_is_stable_for_payload(self) -> None:
+        self.audit()
+        payload = json.loads(self.manifest.read_text())
+        digest = payload.pop("manifest_digest")
+        expected = hashlib.sha256(CBM.canonical_json(payload)).hexdigest()
+        self.assertEqual(digest, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- resolve linked Git worktrees to the checkout that owns their absolute common directory before indexing
- add host-bound, digest-protected cache audit manifests and dry-run-by-default pruning through `delete_project`
- fail closed on invalid roots, unhealthy or missing canonical graphs, drift, corruption, and unsafe prefixes; skip held databases
- document the workflow and update generated skill indexes

## Why

Branch worktrees were being indexed as separate projects, multiplying large SQLite graphs. This makes canonical checkout reuse the default and provides a guarded cleanup path for existing duplicates.

## Validation

- `make test`
- `make validate`
- `make check-generated`
- `pre-commit run --all-files`
- live dry-run audit against 147 projects; no project was deleted
