### PR TITLE
fix(codebase-memory): allow safe partial cache pruning

### DIFF
--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -57,7 +57,7 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
    - Manifests with host blockers fail closed by default. After reviewing every relationship, explicitly add `--allow-blocked-manifest` to preflight and prune only independent candidates while preserving all protected and blocked projects.
    - Apply only the unchanged manifest:
      `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json --apply`
-   - Dry-run and apply preflight every candidate before deletion. Apply then rechecks the snapshot, holder state, candidate rules, and inode/device/size/mtime fingerprints immediately before each deletion.
+   - Dry-run and apply preflight every candidate before deletion. Apply then rechecks the snapshot, candidate rules, and inode/device/size/mtime fingerprints, with the holder probe last immediately before each deletion.
    - Held databases, unmapped or reappeared roots, missing or unhealthy canonical graphs, corrupt databases, drift, fingerprint changes, deletion failures, or database/WAL/SHM residue stop immediately. The failure reports any projects already deleted.
    - Deletion uses `codebase-memory-mcp cli delete_project` only. Never remove project databases directly.
 8. Report exact proof.

--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -54,9 +54,11 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
    - When legacy home symlinks name the same physical checkout, preserve the exact canonical graph and treat only the symlink-named graph as a duplicate. Preserve a sole symlink-named graph.
    - Review the manifest, then dry-run it:
      `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json`
+   - Manifests with host blockers fail closed by default. After reviewing every relationship, explicitly add `--allow-blocked-manifest` to preflight and prune only independent candidates while preserving all protected and blocked projects.
    - Apply only the unchanged manifest:
      `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json --apply`
-   - Apply revalidates host, project snapshot, names, roots, sizes, canonical mapping, clone health, SQLite integrity, and holders before each deletion. Held databases are skipped. Unmapped live roots, missing or unhealthy canonical graphs, corrupt databases, drift, or deletion failures stop the host.
+   - Dry-run and apply preflight every candidate before deletion. Apply then rechecks the snapshot, holder state, candidate rules, and inode/device/size/mtime fingerprints immediately before each deletion.
+   - Held databases, unmapped or reappeared roots, missing or unhealthy canonical graphs, corrupt databases, drift, fingerprint changes, deletion failures, or database/WAL/SHM residue stop immediately. The failure reports any projects already deleted.
    - Deletion uses `codebase-memory-mcp cli delete_project` only. Never remove project databases directly.
 8. Report exact proof.
    - Indexed project name.

--- a/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
+++ b/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
@@ -30,6 +30,8 @@ Options:
   --cache-dir PATH
                   Override the codebase-memory-mcp cache root.
   --apply         Execute cache-prune. Without it, cache-prune is a dry run.
+  --allow-blocked-manifest
+                  Let cache-prune process candidates while preserving blockers.
 EOF
 }
 
@@ -39,6 +41,7 @@ port="9749"
 manifest=""
 cache_dir=""
 apply="false"
+allow_blocked_manifest="false"
 ephemeral_prefixes=()
 command="${1:-}"
 [[ -n "$command" ]] && shift || true
@@ -71,6 +74,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --apply)
       apply="true"
+      shift
+      ;;
+    --allow-blocked-manifest)
+      allow_blocked_manifest="true"
       shift
       ;;
     -h|--help)
@@ -251,6 +258,10 @@ cmd_cache_audit() {
     printf -- '--apply is valid only with cache-prune\n' >&2
     exit 2
   }
+  [[ "$allow_blocked_manifest" == "false" ]] || {
+    printf -- '--allow-blocked-manifest is valid only with cache-prune\n' >&2
+    exit 2
+  }
   helper="$(cache_helper)"
   args=(audit --manifest "$manifest")
   [[ -z "$cache_dir" ]] || args+=(--cache-dir "$cache_dir")
@@ -277,6 +288,7 @@ cmd_cache_prune() {
   args=(prune --manifest "$manifest")
   [[ -z "$cache_dir" ]] || args+=(--cache-dir "$cache_dir")
   [[ "$apply" == "false" ]] || args+=(--apply)
+  [[ "$allow_blocked_manifest" == "false" ]] || args+=(--allow-blocked-manifest)
   python3 "$helper" "${args[@]}"
 }
 

--- a/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
+++ b/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
@@ -77,6 +77,10 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --allow-blocked-manifest)
+      if [[ "$command" != "cache-prune" ]]; then
+        printf -- '--allow-blocked-manifest is valid only with cache-prune\n' >&2
+        exit 2
+      fi
       allow_blocked_manifest="true"
       shift
       ;;
@@ -256,10 +260,6 @@ cmd_cache_audit() {
   }
   [[ "$apply" == "false" ]] || {
     printf -- '--apply is valid only with cache-prune\n' >&2
-    exit 2
-  }
-  [[ "$allow_blocked_manifest" == "false" ]] || {
-    printf -- '--allow-blocked-manifest is valid only with cache-prune\n' >&2
     exit 2
   }
   helper="$(cache_helper)"

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -10,6 +10,7 @@ import pathlib
 import shutil
 import socket
 import sqlite3
+import stat
 import subprocess
 import sys
 import urllib.parse
@@ -476,7 +477,72 @@ def load_manifest(path: pathlib.Path) -> dict[str, Any]:
         raise SafetyError(
             f"manifest host mismatch: {payload.get('host')} != {socket.gethostname()}"
         )
+    validate_manifest_relationships(payload)
     return payload
+
+
+def validate_manifest_relationships(payload: dict[str, Any]) -> None:
+    collections: dict[str, list[dict[str, Any]]] = {}
+    for key in ("snapshot", "candidates", "protected", "blockers"):
+        value = payload.get(key)
+        if not isinstance(value, list) or any(
+            not isinstance(item, dict) for item in value
+        ):
+            raise SafetyError(f"manifest {key} must be an array of objects")
+        collections[key] = value
+
+    prefixes = payload.get("ephemeral_prefixes")
+    if not isinstance(prefixes, list) or any(
+        not isinstance(value, str) for value in prefixes
+    ):
+        raise SafetyError("manifest ephemeral_prefixes must be an array of strings")
+
+    names: dict[str, list[str]] = {}
+    for key, items in collections.items():
+        item_names: list[str] = []
+        for item in items:
+            name = item.get("name")
+            if not isinstance(name, str) or not name:
+                raise SafetyError(f"manifest {key} contains an invalid project name")
+            item_names.append(name)
+        if len(item_names) != len(set(item_names)):
+            raise SafetyError(f"manifest {key} contains duplicate project names")
+        names[key] = item_names
+
+    snapshot_by_name = {
+        item["name"]: item for item in collections["snapshot"]
+    }
+    candidate_names = set(names["candidates"])
+    protected_names = set(names["protected"])
+    snapshot_names = set(names["snapshot"])
+    if candidate_names & protected_names:
+        raise SafetyError("manifest candidates and protected projects overlap")
+    if candidate_names | protected_names != snapshot_names:
+        raise SafetyError(
+            "manifest candidates and protected projects do not partition the snapshot"
+        )
+
+    for key in ("candidates", "protected"):
+        for item in collections[key]:
+            snapshot = snapshot_by_name[item["name"]]
+            for field in ("root_path", "size_bytes"):
+                if item.get(field) != snapshot.get(field):
+                    raise SafetyError(
+                        f"manifest {key} record disagrees with snapshot: {item['name']}"
+                    )
+
+    expected_blockers = [
+        item
+        for item in collections["protected"]
+        if item.get("reason") in HOST_BLOCKING_REASONS
+    ]
+    actual_blockers = collections["blockers"]
+    if sorted(canonical_json(item) for item in actual_blockers) != sorted(
+        canonical_json(item) for item in expected_blockers
+    ):
+        raise SafetyError(
+            "manifest blockers must exactly match blocked protected projects"
+        )
 
 
 def validate_snapshot(
@@ -500,18 +566,62 @@ def db_path(cache_dir: pathlib.Path, project_name: str) -> pathlib.Path:
     return path
 
 
+def cache_paths(path: pathlib.Path) -> list[pathlib.Path]:
+    return [path, pathlib.Path(f"{path}-wal"), pathlib.Path(f"{path}-shm")]
+
+
+def path_exists(path: pathlib.Path) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise SafetyError(f"cannot inspect project cache path {path}: {error}") from error
+    return True
+
+
 def db_is_held(path: pathlib.Path) -> bool:
     lsof = shutil.which("lsof")
     if not lsof:
         raise SafetyError("lsof is required for cache pruning")
-    paths = [path, pathlib.Path(f"{path}-wal"), pathlib.Path(f"{path}-shm")]
-    existing = [str(candidate) for candidate in paths if candidate.exists()]
+    existing = [
+        str(candidate) for candidate in cache_paths(path) if path_exists(candidate)
+    ]
     if not existing:
         return False
     result = run([lsof, "-F", "p", "--", *existing], check=False)
     if result.returncode not in (0, 1):
         raise SafetyError(f"lsof failed for {path}: {result.stderr.strip()}")
     return bool(result.stdout.strip())
+
+
+def cache_fingerprint(path: pathlib.Path) -> dict[str, dict[str, int] | None]:
+    fingerprint: dict[str, dict[str, int] | None] = {}
+    for candidate in cache_paths(path):
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            fingerprint[candidate.name] = None
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SafetyError(
+                f"project cache file is non-regular or symlinked: {candidate}"
+            )
+        fingerprint[candidate.name] = {
+            "device": metadata.st_dev,
+            "inode": metadata.st_ino,
+            "size": metadata.st_size,
+            "mtime_ns": metadata.st_mtime_ns,
+        }
+    return fingerprint
+
+
+def require_cache_absent(path: pathlib.Path) -> None:
+    residue = [
+        str(candidate) for candidate in cache_paths(path) if path_exists(candidate)
+    ]
+    if residue:
+        raise SafetyError("project cache residue remains: " + ", ".join(residue))
 
 
 def validate_database(path: pathlib.Path, expected_size: int) -> None:
@@ -610,6 +720,33 @@ def delete_project(binary: str, project_name: str) -> None:
         raise SafetyError(f"delete_project failed for {project_name}: {detail}")
 
 
+def preflight_candidates(
+    *,
+    binary: str,
+    cache_dir: pathlib.Path,
+    candidates: list[dict[str, Any]],
+    expected_snapshot: list[dict[str, Any]],
+    prefixes: list[pathlib.Path],
+) -> dict[str, dict[str, dict[str, int] | None]]:
+    fingerprints: dict[str, dict[str, dict[str, int] | None]] = {}
+    for candidate in candidates:
+        projects = list_projects(binary)
+        validate_snapshot(expected_snapshot, projects)
+        revalidate_candidate(candidate, projects, prefixes)
+        path = db_path(cache_dir, candidate["name"])
+        before = cache_fingerprint(path)
+        validate_database(path, candidate["size_bytes"])
+        after = cache_fingerprint(path)
+        if after != before:
+            raise SafetyError(
+                f"project cache fingerprint changed during preflight: {candidate['name']}"
+            )
+        if db_is_held(path):
+            raise SafetyError(f"project DB is held: {candidate['name']}")
+        fingerprints[candidate["name"]] = after
+    return fingerprints
+
+
 def audit(args: argparse.Namespace) -> int:
     binary = cbm_binary(args.cbm_bin)
     cache_dir = cbm_cache_dir(args.cache_dir)
@@ -661,11 +798,20 @@ def prune(args: argparse.Namespace) -> int:
     prefixes = [pathlib.Path(value) for value in payload["ephemeral_prefixes"]]
     projects = list_projects(binary)
     validate_snapshot(payload["snapshot"], projects)
-    if payload.get("blockers"):
+    if payload["blockers"] and not args.allow_blocked_manifest:
         reasons = sorted({item["reason"] for item in payload["blockers"]})
         raise SafetyError(
             "host cache manifest is blocked: " + ", ".join(reasons)
         )
+
+    expected_snapshot = list(payload["snapshot"])
+    fingerprints = preflight_candidates(
+        binary=binary,
+        cache_dir=cache_dir,
+        candidates=payload["candidates"],
+        expected_snapshot=expected_snapshot,
+        prefixes=prefixes,
+    )
 
     if not args.apply:
         print(
@@ -681,6 +827,8 @@ def prune(args: argparse.Namespace) -> int:
                     "project_bytes": sum(
                         project["size_bytes"] for project in projects
                     ),
+                    "preflighted": len(fingerprints),
+                    "blocked_manifest_allowed": args.allow_blocked_manifest,
                     "applied": False,
                 },
                 sort_keys=True,
@@ -688,35 +836,49 @@ def prune(args: argparse.Namespace) -> int:
         )
         return 0
 
-    expected_snapshot = list(payload["snapshot"])
     before_projects = len(projects)
     before_bytes = sum(project["size_bytes"] for project in projects)
     deleted: list[dict[str, Any]] = []
-    skipped: list[dict[str, Any]] = []
-    for candidate in payload["candidates"]:
-        projects = list_projects(binary)
-        validate_snapshot(expected_snapshot, projects)
-        revalidate_candidate(candidate, projects, prefixes)
-        path = db_path(cache_dir, candidate["name"])
-        if db_is_held(path):
-            skipped.append({"name": candidate["name"], "reason": "held"})
-            continue
-        validate_database(path, candidate["size_bytes"])
-        delete_project(binary, candidate["name"])
-        projects = list_projects(binary)
-        expected_snapshot = [
-            item
-            for item in expected_snapshot
-            if item["name"] != candidate["name"]
-        ]
-        validate_snapshot(expected_snapshot, projects)
-        deleted.append(
-            {
-                "name": candidate["name"],
-                "bytes": candidate["size_bytes"],
-                "reason": candidate["reason"],
-            }
-        )
+    try:
+        for candidate in payload["candidates"]:
+            projects = list_projects(binary)
+            validate_snapshot(expected_snapshot, projects)
+            path = db_path(cache_dir, candidate["name"])
+            if db_is_held(path):
+                raise SafetyError(f"project DB is held: {candidate['name']}")
+            revalidate_candidate(candidate, projects, prefixes)
+            if cache_fingerprint(path) != fingerprints[candidate["name"]]:
+                raise SafetyError(
+                    f"project cache fingerprint changed: {candidate['name']}"
+                )
+
+            delete_project(binary, candidate["name"])
+            projects = list_projects(binary)
+            if any(
+                project["name"] == candidate["name"] for project in projects
+            ):
+                raise SafetyError(
+                    f"deleted project remains registered: {candidate['name']}"
+                )
+            expected_snapshot = [
+                item
+                for item in expected_snapshot
+                if item["name"] != candidate["name"]
+            ]
+            deleted.append(
+                {
+                    "name": candidate["name"],
+                    "bytes": candidate["size_bytes"],
+                    "reason": candidate["reason"],
+                }
+            )
+            validate_snapshot(expected_snapshot, projects)
+            require_cache_absent(path)
+    except SafetyError as error:
+        already_deleted = [item["name"] for item in deleted]
+        raise SafetyError(
+            f"{error}; already_deleted={json.dumps(already_deleted)}"
+        ) from error
 
     print(
         json.dumps(
@@ -726,7 +888,8 @@ def prune(args: argparse.Namespace) -> int:
                 "applied": True,
                 "deleted": deleted,
                 "deleted_bytes": sum(item["bytes"] for item in deleted),
-                "skipped": skipped,
+                "skipped": [],
+                "blocked_manifest_allowed": args.allow_blocked_manifest,
                 "before_projects": before_projects,
                 "before_bytes": before_bytes,
                 "after_projects": len(projects),
@@ -758,6 +921,7 @@ def parser() -> argparse.ArgumentParser:
     prune_parser.add_argument("--cache-dir")
     prune_parser.add_argument("--cbm-bin")
     prune_parser.add_argument("--apply", action="store_true")
+    prune_parser.add_argument("--allow-blocked-manifest", action="store_true")
     return root
 
 

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -795,7 +795,15 @@ def prune(args: argparse.Namespace) -> int:
         raise SafetyError(
             f"cache root mismatch: {cache_dir} != {payload.get('cache_dir')}"
         )
-    prefixes = [pathlib.Path(value) for value in payload["ephemeral_prefixes"]]
+    home = pathlib.Path.home().resolve()
+    prefixes = []
+    for value in payload["ephemeral_prefixes"]:
+        normalized = normalize_prefix(value, cache_dir=cache_dir, home=home)
+        if value != str(normalized):
+            raise SafetyError(
+                f"manifest ephemeral prefix is not normalized: {value}"
+            )
+        prefixes.append(normalized)
     projects = list_projects(binary)
     validate_snapshot(payload["snapshot"], projects)
     if payload["blockers"] and not args.allow_blocked_manifest:
@@ -844,13 +852,13 @@ def prune(args: argparse.Namespace) -> int:
             projects = list_projects(binary)
             validate_snapshot(expected_snapshot, projects)
             path = db_path(cache_dir, candidate["name"])
-            if db_is_held(path):
-                raise SafetyError(f"project DB is held: {candidate['name']}")
             revalidate_candidate(candidate, projects, prefixes)
             if cache_fingerprint(path) != fingerprints[candidate["name"]]:
                 raise SafetyError(
                     f"project cache fingerprint changed: {candidate['name']}"
                 )
+            if db_is_held(path):
+                raise SafetyError(f"project DB is held: {candidate['name']}")
 
             delete_project(binary, candidate["name"])
             projects = list_projects(binary)

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -176,6 +176,12 @@ import json, os, pathlib, sys
 state = pathlib.Path(os.environ["FAKE_CBM_STATE"])
 payload = json.loads(state.read_text())
 if sys.argv[1:3] == ["cli", "list_projects"]:
+    calls = pathlib.Path(os.environ["FAKE_CBM_LIST_CALLS"])
+    call = int(calls.read_text()) if calls.exists() else 0
+    calls.write_text(str(call + 1))
+    if os.environ.get("FAKE_CBM_MUTATE_ON_LIST_CALL") == str(call + 1):
+        with pathlib.Path(os.environ["FAKE_CBM_MUTATE_PATH"]).open("ab") as handle:
+            handle.write(b"x")
     print(json.dumps({"projects": payload}))
     raise SystemExit(0)
 if sys.argv[1:3] == ["cli", "delete_project"]:
@@ -213,9 +219,6 @@ if statuses:
     status = values[min(call, len(values) - 1)]
 else:
     status = int(os.environ.get("FAKE_LSOF_STATUS", "1"))
-if os.environ.get("FAKE_LSOF_MUTATE_ON_CALL") == str(call + 1):
-    with pathlib.Path(sys.argv[-1]).open("ab") as handle:
-        handle.write(b"x")
 if status == 0:
     print("p123")
 raise SystemExit(status)
@@ -227,6 +230,7 @@ raise SystemExit(status)
             "PATH": f"{self.bin}:{os.environ['PATH']}",
             "FAKE_CBM_STATE": str(self.state),
             "FAKE_CBM_DELETED": str(self.deleted),
+            "FAKE_CBM_LIST_CALLS": str(self.temp / "list-calls"),
             "FAKE_LSOF_STATE": str(self.temp / "lsof-state"),
             "CBM_CACHE_DIR": str(self.cache),
         }
@@ -468,7 +472,7 @@ raise SystemExit(status)
                 "remote.origin.promisor",
             )
 
-    def test_holder_after_preflight_stops_before_first_delete(self) -> None:
+    def test_holder_opened_after_final_revalidation_stops_before_delete(self) -> None:
         self.audit()
         environment = {
             **self.environment,
@@ -482,9 +486,14 @@ raise SystemExit(status)
 
     def test_fingerprint_change_after_preflight_stops_before_delete(self) -> None:
         self.audit()
+        list_calls = pathlib.Path(self.environment["FAKE_CBM_LIST_CALLS"])
+        list_calls.write_text("0")
         environment = {
             **self.environment,
-            "FAKE_LSOF_MUTATE_ON_CALL": "2",
+            "FAKE_CBM_MUTATE_ON_LIST_CALL": "3",
+            "FAKE_CBM_MUTATE_PATH": str(
+                self.cache / f"{self.worktree_name}.db"
+            ),
         }
         result = self.apply(check=False, env=environment)
         self.assertNotEqual(result.returncode, 0)
@@ -560,6 +569,53 @@ raise SystemExit(status)
         )
         self.assertNotEqual(unsafe.returncode, 0)
         self.assertIn("unsafe ephemeral prefix", unsafe.stderr)
+
+    def test_prune_rejects_unsafe_or_non_normalized_manifest_prefixes(self) -> None:
+        prefix = self.temp / "ephemeral"
+        self.add_ephemeral_candidate("fixture-ephemeral")
+        self.audit("--ephemeral-prefix", str(prefix))
+        unsafe_prefixes = {
+            "root": "/",
+            "home": str(pathlib.Path.home()),
+            "cache": str(self.cache),
+            "relative": "relative/path",
+            "non-normalized": str(prefix / ".." / "other"),
+            "unexpanded-home": "~/ephemeral",
+        }
+        for name, unsafe_prefix in unsafe_prefixes.items():
+            with self.subTest(name=name):
+                payload = json.loads(self.manifest.read_text())
+                payload["ephemeral_prefixes"] = [unsafe_prefix]
+                self.rewrite_manifest(payload)
+                result = self.apply(check=False)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("ephemeral prefix", result.stderr)
+                self.assertFalse(self.deleted.exists())
+
+    def test_allow_blocked_manifest_is_rejected_outside_cache_prune(self) -> None:
+        commands = (
+            "init",
+            "index",
+            "canonical",
+            "start-ui",
+            "stop-ui",
+            "status",
+            "schema",
+            "cache-audit",
+            "keepalive",
+        )
+        for command_name in commands:
+            with self.subTest(command=command_name):
+                result = self.run_script(
+                    command_name,
+                    "--allow-blocked-manifest",
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(
+                    "--allow-blocked-manifest is valid only with cache-prune",
+                    result.stderr,
+                )
 
     def test_unmapped_live_root_blocks_the_host(self) -> None:
         invalid_root = self.temp / "invalid-live-root"

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -183,7 +183,18 @@ if sys.argv[1:3] == ["cli", "delete_project"]:
     deleted = pathlib.Path(os.environ["FAKE_CBM_DELETED"])
     with deleted.open("a") as handle:
         handle.write(json.dumps({"project": name}) + "\\n")
+    if os.environ.get("FAKE_CBM_DELETE_FAIL") == name:
+        print(f"forced delete failure: {name}", file=sys.stderr)
+        raise SystemExit(1)
     state.write_text(json.dumps([item for item in payload if item["name"] != name]))
+    database = pathlib.Path(os.environ["CBM_CACHE_DIR"]) / f"{name}.db"
+    for suffix in ("", "-wal", "-shm"):
+        pathlib.Path(f"{database}{suffix}").unlink(missing_ok=True)
+    for suffix in os.environ.get("FAKE_CBM_RESIDUE_SUFFIXES", "").split(","):
+        if suffix:
+            pathlib.Path(f"{database}-{suffix}").write_bytes(b"residue")
+    if os.environ.get("FAKE_CBM_RESIDUE_DB") == "1":
+        database.write_bytes(b"residue")
     raise SystemExit(0)
 raise SystemExit(2)
 """
@@ -191,10 +202,24 @@ raise SystemExit(2)
         fake_cbm.chmod(0o755)
         fake_lsof = self.bin / "lsof"
         fake_lsof.write_text(
-            '#!/bin/sh\n'
-            'status="${FAKE_LSOF_STATUS:-1}"\n'
-            '[ "$status" -ne 0 ] || printf "p123\\n"\n'
-            'exit "$status"\n'
+            """#!/usr/bin/env python3
+import os, pathlib, sys
+state = pathlib.Path(os.environ["FAKE_LSOF_STATE"])
+call = int(state.read_text()) if state.exists() else 0
+state.write_text(str(call + 1))
+statuses = os.environ.get("FAKE_LSOF_STATUSES")
+if statuses:
+    values = [int(value) for value in statuses.split(",")]
+    status = values[min(call, len(values) - 1)]
+else:
+    status = int(os.environ.get("FAKE_LSOF_STATUS", "1"))
+if os.environ.get("FAKE_LSOF_MUTATE_ON_CALL") == str(call + 1):
+    with pathlib.Path(sys.argv[-1]).open("ab") as handle:
+        handle.write(b"x")
+if status == 0:
+    print("p123")
+raise SystemExit(status)
+"""
         )
         fake_lsof.chmod(0o755)
         self.environment = {
@@ -202,6 +227,7 @@ raise SystemExit(2)
             "PATH": f"{self.bin}:{os.environ['PATH']}",
             "FAKE_CBM_STATE": str(self.state),
             "FAKE_CBM_DELETED": str(self.deleted),
+            "FAKE_LSOF_STATE": str(self.temp / "lsof-state"),
             "CBM_CACHE_DIR": str(self.cache),
         }
 
@@ -232,17 +258,46 @@ raise SystemExit(2)
             *extra,
         )
 
-    def apply(self, *, check: bool = True, env: dict[str, str] | None = None):
-        return self.run_script(
+    def apply(
+        self,
+        *,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+        allow_blocked: bool = False,
+    ):
+        args = [
             "cache-prune",
             "--manifest",
             str(self.manifest),
             "--cache-dir",
             str(self.cache),
             "--apply",
+        ]
+        if allow_blocked:
+            args.append("--allow-blocked-manifest")
+        return self.run_script(
+            *args,
             check=check,
             env=env,
         )
+
+    def rewrite_manifest(self, payload: dict[str, object]) -> None:
+        payload["manifest_digest"] = CBM.manifest_digest(payload)
+        self.manifest.write_text(json.dumps(payload))
+
+    def add_ephemeral_candidate(self, name: str) -> pathlib.Path:
+        missing = self.temp / "ephemeral" / name
+        self.projects.append(
+            {
+                "name": name,
+                "root_path": str(missing),
+                "size_bytes": sqlite_file(self.cache / f"{name}.db"),
+                "nodes": 1,
+                "edges": 1,
+            }
+        )
+        self.write_projects(self.projects)
+        return missing
 
     def test_prune_is_dry_run_by_default(self) -> None:
         self.audit()
@@ -254,7 +309,9 @@ raise SystemExit(2)
             str(self.cache),
         )
         self.assertFalse(self.deleted.exists())
-        self.assertFalse(json.loads(result.stdout)["applied"])
+        payload = json.loads(result.stdout)
+        self.assertFalse(payload["applied"])
+        self.assertEqual(payload["preflighted"], 1)
 
     def test_unchanged_manifest_applies_through_delete_project(self) -> None:
         self.audit()
@@ -267,6 +324,7 @@ raise SystemExit(2)
         )
         remaining = json.loads(self.state.read_text())
         self.assertEqual([item["name"] for item in remaining], [self.main_name])
+        self.assertFalse((self.cache / f"{self.worktree_name}.db").exists())
 
     def test_symlink_named_graph_is_a_guarded_alias_duplicate(self) -> None:
         alias = self.temp / "legacy-home" / "repo"
@@ -332,21 +390,21 @@ raise SystemExit(2)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("manifest digest mismatch", result.stderr)
 
-    def test_held_database_is_skipped(self) -> None:
+    def test_held_database_stops_preflight_without_delete(self) -> None:
         self.audit()
         environment = {**self.environment, "FAKE_LSOF_STATUS": "0"}
-        result = self.apply(env=environment)
-        payload = json.loads(result.stdout)
-        self.assertEqual(
-            payload["skipped"], [{"name": self.worktree_name, "reason": "held"}]
-        )
+        result = self.apply(check=False, env=environment)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("project DB is held", result.stderr)
         self.assertFalse(self.deleted.exists())
 
-    def test_corrupt_database_stops_apply(self) -> None:
-        corrupt = self.cache / f"{self.worktree_name}.db"
+    def test_corrupt_later_candidate_stops_preflight_without_delete(self) -> None:
+        name = "fixture-z-corrupt"
+        self.add_ephemeral_candidate(name)
+        corrupt = self.cache / f"{name}.db"
         size = corrupt.stat().st_size
         corrupt.write_bytes(b"x" * size)
-        self.audit()
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
         result = self.apply(check=False)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("corrupt", result.stderr)
@@ -360,6 +418,16 @@ raise SystemExit(2)
         result = self.apply(check=False)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("manifest drift", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_reappeared_ephemeral_root_stops_preflight_without_delete(self) -> None:
+        missing = self.add_ephemeral_candidate("fixture-z-ephemeral")
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        missing.mkdir(parents=True)
+        result = self.apply(check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ephemeral root became live", result.stderr)
+        self.assertFalse(self.deleted.exists())
 
     def test_missing_live_root_and_canonical_root_stop_apply(self) -> None:
         for removed in ("worktree", "main"):
@@ -374,6 +442,93 @@ raise SystemExit(2)
                     self.assertFalse(self.deleted.exists())
                 finally:
                     renamed.rename(target)
+
+    def test_clone_health_change_stops_preflight_without_delete(self) -> None:
+        self.audit()
+        command(
+            "git",
+            "-C",
+            str(self.main),
+            "config",
+            "remote.origin.promisor",
+            "true",
+        )
+        try:
+            result = self.apply(check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("canonical clone is not full", result.stderr)
+            self.assertFalse(self.deleted.exists())
+        finally:
+            command(
+                "git",
+                "-C",
+                str(self.main),
+                "config",
+                "--unset",
+                "remote.origin.promisor",
+            )
+
+    def test_holder_after_preflight_stops_before_first_delete(self) -> None:
+        self.audit()
+        environment = {
+            **self.environment,
+            "FAKE_LSOF_STATUSES": "1,0",
+        }
+        result = self.apply(check=False, env=environment)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("project DB is held", result.stderr)
+        self.assertIn("already_deleted=[]", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_fingerprint_change_after_preflight_stops_before_delete(self) -> None:
+        self.audit()
+        environment = {
+            **self.environment,
+            "FAKE_LSOF_MUTATE_ON_CALL": "2",
+        }
+        result = self.apply(check=False, env=environment)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("fingerprint changed", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_delete_failure_reports_prior_deletion(self) -> None:
+        failing = "fixture-z-delete-fail"
+        self.add_ephemeral_candidate(failing)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        environment = {
+            **self.environment,
+            "FAKE_CBM_DELETE_FAIL": failing,
+        }
+        result = self.apply(check=False, env=environment)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("delete_project failed", result.stderr)
+        self.assertIn(
+            f'already_deleted=["{self.worktree_name}"]',
+            result.stderr,
+        )
+
+    def test_database_and_sidecar_residue_stop_apply(self) -> None:
+        self.audit()
+        environment = {
+            **self.environment,
+            "FAKE_CBM_RESIDUE_DB": "1",
+            "FAKE_CBM_RESIDUE_SUFFIXES": "wal,shm",
+        }
+        result = self.apply(check=False, env=environment)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("project cache residue remains", result.stderr)
+        self.assertIn(
+            f'already_deleted=["{self.worktree_name}"]',
+            result.stderr,
+        )
+        database = self.cache / f"{self.worktree_name}.db"
+        residue = (
+            database,
+            pathlib.Path(f"{database}-wal"),
+            pathlib.Path(f"{database}-shm"),
+        )
+        for path in residue:
+            self.assertTrue(path.exists())
 
     def test_ephemeral_prefix_guards_missing_roots(self) -> None:
         missing = self.temp / "ephemeral" / "gone"
@@ -432,6 +587,55 @@ raise SystemExit(2)
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("host cache manifest is blocked", result.stderr)
+
+        dry_run = self.run_script(
+            "cache-prune",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            "--allow-blocked-manifest",
+        )
+        dry_payload = json.loads(dry_run.stdout)
+        self.assertFalse(dry_payload["applied"])
+        self.assertEqual(dry_payload["preflighted"], 1)
+        self.assertFalse(self.deleted.exists())
+
+        applied = self.apply(allow_blocked=True)
+        applied_payload = json.loads(applied.stdout)
+        self.assertEqual(
+            [item["name"] for item in applied_payload["deleted"]],
+            [self.worktree_name],
+        )
+        remaining = {
+            item["name"] for item in json.loads(self.state.read_text())
+        }
+        self.assertEqual(remaining, {self.main_name, name})
+        self.assertTrue((self.cache / f"{name}.db").exists())
+
+    def test_malformed_manifest_relationships_are_rejected(self) -> None:
+        mutations = {
+            "blockers": lambda payload: payload["blockers"].append(
+                payload["protected"][0]
+            ),
+            "overlap": lambda payload: payload["candidates"].append(
+                payload["protected"][0]
+            ),
+            "partition": lambda payload: payload["protected"].pop(0),
+            "duplicates": lambda payload: payload["candidates"].append(
+                payload["candidates"][0]
+            ),
+        }
+        for name, mutate in mutations.items():
+            with self.subTest(name=name):
+                self.audit()
+                payload = json.loads(self.manifest.read_text())
+                mutate(payload)
+                self.rewrite_manifest(payload)
+                result = self.apply(check=False)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("manifest", result.stderr)
+                self.assertFalse(self.deleted.exists())
 
     def test_manifest_digest_is_stable_for_payload(self) -> None:
         self.audit()


### PR DESCRIPTION
## What changed

- add strict opt-in `cache-prune --allow-blocked-manifest` so independently safe candidates can be pruned while blocked and protected projects remain untouched
- validate manifest partitions and blocker relationships before pruning
- preflight every candidate before the first deletion, then recheck holder state, repository mapping, clone health, and DB/WAL/SHM fingerprints before each CLI deletion
- require registry and filesystem postconditions after every deletion and report already deleted projects on failure
- document the strict-default workflow and replace held-database skipping with fail-closed behavior

## Why

A blocked manifest previously prevented all pruning, even when its blockers were unrelated to otherwise safe candidates. The opt-in path preserves the default fail-closed behavior while allowing reviewed candidates to proceed under a two-phase safety protocol.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.codebase_memory_cache_test` (23 tests)
- `make validate`
- `make marketplace && make releases-index`
- `make check-generated`
- `PYTHONDONTWRITEBYTECODE=1 pre-commit run --all-files`
- `shellcheck skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh`
- `git diff --check`

## Notes

- no manifest schema bump; the existing schema contains the relationships and file metadata needed for stricter validation
- no generated index changes were produced after regeneration
