### PR TITLE
feat(codebase-memory): protect exact prune candidates

### DIFF
--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -55,16 +55,18 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
    - Review the manifest, then dry-run it:
      `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json`
    - Manifests with host blockers fail closed by default. After reviewing every relationship, explicitly add `--allow-blocked-manifest` to preflight and prune only independent candidates while preserving all protected and blocked projects.
+   - To retain an exact manifest candidate at runtime, repeat `--protect-candidate NAME` on `cache-prune`. Each named candidate must still exist in the unchanged snapshot and pass its root, prefix, classification, canonical mapping, and clone-health rules. It remains in the expected snapshot but is excluded from DB integrity preflight and deletion.
+   - Runtime candidate protection does not bypass host blockers; add `--allow-blocked-manifest` independently when blockers were reviewed. Unknown, duplicate, or non-candidate names fail before preflight.
    - Apply only the unchanged manifest:
      `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json --apply`
-   - Dry-run and apply preflight every candidate before deletion. Preflight probes holders before SQLite, snapshots regular DB/WAL/SHM files, rejects nonzero WAL, runs `quick_check` through exact `mode=ro&immutable=1`, requires every fingerprint including SHM to remain unchanged, then probes holders again. An absent or zero-byte WAL and a stable regular SHM are allowed.
+   - Dry-run and apply preflight every eligible candidate before deletion. Preflight probes holders before SQLite, snapshots regular DB/WAL/SHM files, rejects nonzero WAL, runs `quick_check` through exact `mode=ro&immutable=1`, requires every fingerprint including SHM to remain unchanged, then probes holders again. An absent or zero-byte WAL and a stable regular SHM are allowed.
    - Apply then rechecks the snapshot, candidate rules, and inode/device/size/mtime fingerprints, with the holder probe last immediately before each deletion. Held databases, nonregular sidecars, nonzero WAL, corrupt databases, drift, fingerprint changes, deletion failures, or database/WAL/SHM residue stop immediately. The failure reports any projects already deleted.
    - Deletion uses `codebase-memory-mcp cli delete_project` only. Never remove project databases directly.
 8. Report exact proof.
    - Indexed project name.
    - Node and edge counts when available.
    - UI URL and tmux session name.
-   - For cleanup: manifest path and digest, before/after project and byte totals, deleted project names, protected/skipped reasons, and any stop condition.
+   - For cleanup: manifest path and digest, manifest/eligible/preflighted candidate totals, runtime protected names/reasons/bytes, before/after project and byte totals, deleted project names, and any stop condition.
    - Missing binaries, unavailable MCP tools, or incomplete proof.
 
 ## Inputs
@@ -72,7 +74,7 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
 - Repository path.
 - Index mode: `fast`, `moderate`, `full`, or `cross-repo-intelligence`.
 - Optional UI port; default `9749`.
-- For cache maintenance: a host-local manifest path and optional explicit ephemeral prefixes.
+- For cache maintenance: a host-local manifest path, optional explicit ephemeral prefixes, and optional exact runtime protected candidate names.
 
 ## Outputs
 

--- a/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
+++ b/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
@@ -32,6 +32,8 @@ Options:
   --apply         Execute cache-prune. Without it, cache-prune is a dry run.
   --allow-blocked-manifest
                   Let cache-prune process candidates while preserving blockers.
+  --protect-candidate NAME
+                  Keep one exact manifest candidate. Repeat for more than one.
 EOF
 }
 
@@ -42,6 +44,7 @@ manifest=""
 cache_dir=""
 apply="false"
 allow_blocked_manifest="false"
+protect_candidates=()
 ephemeral_prefixes=()
 command="${1:-}"
 [[ -n "$command" ]] && shift || true
@@ -83,6 +86,14 @@ while [[ $# -gt 0 ]]; do
       fi
       allow_blocked_manifest="true"
       shift
+      ;;
+    --protect-candidate)
+      if [[ "$command" != "cache-prune" ]]; then
+        printf -- '--protect-candidate is valid only with cache-prune\n' >&2
+        exit 2
+      fi
+      protect_candidates+=("${2:?--protect-candidate requires a name}")
+      shift 2
       ;;
     -h|--help)
       usage
@@ -289,6 +300,10 @@ cmd_cache_prune() {
   [[ -z "$cache_dir" ]] || args+=(--cache-dir "$cache_dir")
   [[ "$apply" == "false" ]] || args+=(--apply)
   [[ "$allow_blocked_manifest" == "false" ]] || args+=(--allow-blocked-manifest)
+  local protected
+  for protected in "${protect_candidates[@]}"; do
+    args+=(--protect-candidate "$protected")
+  done
   python3 "$helper" "${args[@]}"
 }
 

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -770,16 +770,18 @@ def runtime_protected_candidates(
         raise SafetyError("duplicate --protect-candidate name")
 
     snapshot_names = {item["name"] for item in payload["snapshot"]}
-    candidates = {item["name"]: item for item in payload["candidates"]}
-    protected: list[dict[str, Any]] = []
+    candidates = {item["name"] for item in payload["candidates"]}
     for name in names:
         if name not in snapshot_names:
             raise SafetyError(f"unknown --protect-candidate name: {name}")
-        candidate = candidates.get(name)
-        if candidate is None:
+        if name not in candidates:
             raise SafetyError(f"project is not a manifest candidate: {name}")
-        protected.append(candidate)
-    return protected
+    selected_names = set(names)
+    return [
+        item
+        for item in payload["candidates"]
+        if item["name"] in selected_names
+    ]
 
 
 def candidate_execution_summary(

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -763,6 +763,62 @@ def preflight_candidates(
     return fingerprints
 
 
+def runtime_protected_candidates(
+    payload: dict[str, Any], names: list[str]
+) -> list[dict[str, Any]]:
+    if len(names) != len(set(names)):
+        raise SafetyError("duplicate --protect-candidate name")
+
+    snapshot_names = {item["name"] for item in payload["snapshot"]}
+    candidates = {item["name"]: item for item in payload["candidates"]}
+    protected: list[dict[str, Any]] = []
+    for name in names:
+        if name not in snapshot_names:
+            raise SafetyError(f"unknown --protect-candidate name: {name}")
+        candidate = candidates.get(name)
+        if candidate is None:
+            raise SafetyError(f"project is not a manifest candidate: {name}")
+        protected.append(candidate)
+    return protected
+
+
+def candidate_execution_summary(
+    *,
+    manifest_candidates: list[dict[str, Any]],
+    eligible_candidates: list[dict[str, Any]],
+    runtime_protected: list[dict[str, Any]],
+    fingerprints: dict[str, dict[str, dict[str, int] | None]],
+) -> dict[str, Any]:
+    manifest_bytes = sum(item["size_bytes"] for item in manifest_candidates)
+    eligible_bytes = sum(item["size_bytes"] for item in eligible_candidates)
+    protected_report = [
+        {
+            "name": item["name"],
+            "reason": item["reason"],
+            "bytes": item["size_bytes"],
+        }
+        for item in runtime_protected
+    ]
+    return {
+        "candidates": len(manifest_candidates),
+        "candidate_bytes": manifest_bytes,
+        "manifest_candidates": len(manifest_candidates),
+        "manifest_candidate_bytes": manifest_bytes,
+        "eligible_candidates": len(eligible_candidates),
+        "eligible_candidate_bytes": eligible_bytes,
+        "preflighted": len(fingerprints),
+        "preflighted_bytes": sum(
+            candidate["size_bytes"]
+            for candidate in eligible_candidates
+            if candidate["name"] in fingerprints
+        ),
+        "runtime_protected": protected_report,
+        "runtime_protected_bytes": sum(
+            item["bytes"] for item in protected_report
+        ),
+    }
+
+
 def audit(args: argparse.Namespace) -> int:
     binary = cbm_binary(args.cbm_bin)
     cache_dir = cbm_cache_dir(args.cache_dir)
@@ -805,6 +861,15 @@ def audit(args: argparse.Namespace) -> int:
 def prune(args: argparse.Namespace) -> int:
     manifest_path = pathlib.Path(args.manifest).expanduser().resolve()
     payload = load_manifest(manifest_path)
+    runtime_protected = runtime_protected_candidates(
+        payload, args.protect_candidate
+    )
+    protected_names = {item["name"] for item in runtime_protected}
+    eligible_candidates = [
+        item
+        for item in payload["candidates"]
+        if item["name"] not in protected_names
+    ]
     binary = cbm_binary(args.cbm_bin)
     cache_dir = cbm_cache_dir(args.cache_dir)
     if str(cache_dir) != payload.get("cache_dir"):
@@ -829,12 +894,20 @@ def prune(args: argparse.Namespace) -> int:
         )
 
     expected_snapshot = list(payload["snapshot"])
+    for candidate in runtime_protected:
+        revalidate_candidate(candidate, projects, prefixes)
     fingerprints = preflight_candidates(
         binary=binary,
         cache_dir=cache_dir,
-        candidates=payload["candidates"],
+        candidates=eligible_candidates,
         expected_snapshot=expected_snapshot,
         prefixes=prefixes,
+    )
+    execution_summary = candidate_execution_summary(
+        manifest_candidates=payload["candidates"],
+        eligible_candidates=eligible_candidates,
+        runtime_protected=runtime_protected,
+        fingerprints=fingerprints,
     )
 
     if not args.apply:
@@ -843,15 +916,11 @@ def prune(args: argparse.Namespace) -> int:
                 {
                     "action": "prune",
                     "manifest": str(manifest_path),
-                    "candidates": len(payload["candidates"]),
-                    "candidate_bytes": sum(
-                        item["size_bytes"] for item in payload["candidates"]
-                    ),
+                    **execution_summary,
                     "projects": len(projects),
                     "project_bytes": sum(
                         project["size_bytes"] for project in projects
                     ),
-                    "preflighted": len(fingerprints),
                     "blocked_manifest_allowed": args.allow_blocked_manifest,
                     "applied": False,
                 },
@@ -864,7 +933,7 @@ def prune(args: argparse.Namespace) -> int:
     before_bytes = sum(project["size_bytes"] for project in projects)
     deleted: list[dict[str, Any]] = []
     try:
-        for candidate in payload["candidates"]:
+        for candidate in eligible_candidates:
             projects = list_projects(binary)
             validate_snapshot(expected_snapshot, projects)
             path = db_path(cache_dir, candidate["name"])
@@ -909,6 +978,7 @@ def prune(args: argparse.Namespace) -> int:
             {
                 "action": "prune",
                 "manifest": str(manifest_path),
+                **execution_summary,
                 "applied": True,
                 "deleted": deleted,
                 "deleted_bytes": sum(item["bytes"] for item in deleted),
@@ -946,6 +1016,7 @@ def parser() -> argparse.ArgumentParser:
     prune_parser.add_argument("--cbm-bin")
     prune_parser.add_argument("--apply", action="store_true")
     prune_parser.add_argument("--allow-blocked-manifest", action="store_true")
+    prune_parser.add_argument("--protect-candidate", action="append", default=[])
     return root
 
 

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -357,6 +357,7 @@ raise SystemExit(status)
         check: bool = True,
         env: dict[str, str] | None = None,
         allow_blocked: bool = False,
+        protect: tuple[str, ...] = (),
     ):
         args = [
             "cache-prune",
@@ -368,6 +369,8 @@ raise SystemExit(status)
         ]
         if allow_blocked:
             args.append("--allow-blocked-manifest")
+        for name in protect:
+            args.extend(("--protect-candidate", name))
         return self.run_script(
             *args,
             check=check,
@@ -594,6 +597,135 @@ raise SystemExit(status)
         self.assertIn("corrupt", result.stderr)
         self.assertFalse(self.deleted.exists())
 
+    def test_protect_candidate_rejects_duplicate_unknown_and_non_candidate(self) -> None:
+        self.audit()
+        cases = {
+            "duplicate": (
+                (self.worktree_name, self.worktree_name),
+                "duplicate --protect-candidate",
+            ),
+            "unknown": (("fixture-missing",), "unknown --protect-candidate"),
+            "non-candidate": (
+                (self.main_name,),
+                "not a manifest candidate",
+            ),
+        }
+        for name, (protected, message) in cases.items():
+            with self.subTest(name=name):
+                result = self.apply(
+                    check=False,
+                    protect=protected,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(message, result.stderr)
+                self.assertFalse(self.deleted.exists())
+
+    def test_protected_corrupt_candidate_leaves_exact_data_untouched(self) -> None:
+        corrupt_name = "fixture-a-corrupt"
+        clean_name = "fixture-z-clean"
+        self.add_ephemeral_candidate(corrupt_name)
+        self.add_ephemeral_candidate(clean_name)
+        corrupt_database = self.cache / f"{corrupt_name}.db"
+        corrupt_database.write_bytes(b"x" * corrupt_database.stat().st_size)
+        pathlib.Path(f"{corrupt_database}-wal").write_bytes(b"orphan")
+        pathlib.Path(f"{corrupt_database}-shm").write_bytes(b"\0" * 32768)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        manifest = json.loads(self.manifest.read_text())
+        corrupt_candidate = next(
+            item
+            for item in manifest["candidates"]
+            if item["name"] == corrupt_name
+        )
+        eligible = [
+            item
+            for item in manifest["candidates"]
+            if item["name"] != corrupt_name
+        ]
+        before = CBM.cache_fingerprint(corrupt_database)
+        expected_summary = {
+            "candidates": len(manifest["candidates"]),
+            "candidate_bytes": sum(
+                item["size_bytes"] for item in manifest["candidates"]
+            ),
+            "manifest_candidates": len(manifest["candidates"]),
+            "manifest_candidate_bytes": sum(
+                item["size_bytes"] for item in manifest["candidates"]
+            ),
+            "eligible_candidates": len(eligible),
+            "eligible_candidate_bytes": sum(
+                item["size_bytes"] for item in eligible
+            ),
+            "preflighted": len(eligible),
+            "preflighted_bytes": sum(item["size_bytes"] for item in eligible),
+            "runtime_protected": [
+                {
+                    "name": corrupt_name,
+                    "reason": corrupt_candidate["reason"],
+                    "bytes": corrupt_candidate["size_bytes"],
+                }
+            ],
+            "runtime_protected_bytes": corrupt_candidate["size_bytes"],
+        }
+
+        dry_run = self.run_script(
+            "cache-prune",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            "--protect-candidate",
+            corrupt_name,
+        )
+        dry_payload = json.loads(dry_run.stdout)
+        for key, value in expected_summary.items():
+            self.assertEqual(dry_payload[key], value)
+        self.assertFalse(self.deleted.exists())
+        self.assertEqual(CBM.cache_fingerprint(corrupt_database), before)
+
+        applied = self.apply(protect=(corrupt_name,))
+        applied_payload = json.loads(applied.stdout)
+        for key, value in expected_summary.items():
+            self.assertEqual(applied_payload[key], value)
+        self.assertEqual(
+            [item["name"] for item in applied_payload["deleted"]],
+            [self.worktree_name, clean_name],
+        )
+        remaining = {
+            item["name"] for item in json.loads(self.state.read_text())
+        }
+        self.assertEqual(remaining, {self.main_name, corrupt_name})
+        self.assertEqual(CBM.cache_fingerprint(corrupt_database), before)
+
+    def test_protected_ephemeral_root_reappearing_fails(self) -> None:
+        name = "fixture-protected-ephemeral"
+        missing = self.add_ephemeral_candidate(name)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        missing.mkdir(parents=True)
+        result = self.apply(check=False, protect=(name,))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ephemeral root became live", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_protected_candidate_classification_drift_fails(self) -> None:
+        self.audit()
+        command(
+            "git",
+            "-C",
+            str(self.main),
+            "worktree",
+            "remove",
+            "--force",
+            str(self.worktree),
+        )
+        command("git", "clone", "-q", str(self.main), str(self.worktree))
+        result = self.apply(
+            check=False,
+            protect=(self.worktree_name,),
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate canonical root changed", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
     def test_project_snapshot_change_stops_apply(self) -> None:
         self.audit()
         changed = json.loads(self.state.read_text())
@@ -651,6 +783,91 @@ raise SystemExit(status)
                 "--unset",
                 "remote.origin.promisor",
             )
+
+    def test_protection_does_not_bypass_eligible_holder(self) -> None:
+        protected = "fixture-protected"
+        self.add_ephemeral_candidate(protected)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        environment = {**self.environment, "FAKE_LSOF_STATUS": "0"}
+        result = self.apply(
+            check=False,
+            env=environment,
+            protect=(protected,),
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("project DB is held", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_protection_does_not_bypass_eligible_wal(self) -> None:
+        protected = "fixture-protected"
+        self.add_ephemeral_candidate(protected)
+        database = self.cache / f"{self.worktree_name}.db"
+        pathlib.Path(f"{database}-wal").write_bytes(b"orphan")
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        result = self.apply(check=False, protect=(protected,))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("project WAL is nonzero", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_protection_does_not_bypass_eligible_clone_health(self) -> None:
+        protected = "fixture-protected"
+        self.add_ephemeral_candidate(protected)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        command(
+            "git",
+            "-C",
+            str(self.main),
+            "config",
+            "remote.origin.promisor",
+            "true",
+        )
+        try:
+            result = self.apply(check=False, protect=(protected,))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("canonical clone is not full", result.stderr)
+            self.assertFalse(self.deleted.exists())
+        finally:
+            command(
+                "git",
+                "-C",
+                str(self.main),
+                "config",
+                "--unset",
+                "remote.origin.promisor",
+            )
+
+    def test_protection_does_not_bypass_eligible_canonical_mapping(self) -> None:
+        protected = "fixture-protected"
+        self.add_ephemeral_candidate(protected)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        command(
+            "git",
+            "-C",
+            str(self.main),
+            "worktree",
+            "remove",
+            "--force",
+            str(self.worktree),
+        )
+        command("git", "clone", "-q", str(self.main), str(self.worktree))
+        result = self.apply(check=False, protect=(protected,))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("candidate canonical root changed", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_protection_does_not_bypass_snapshot_drift(self) -> None:
+        protected = "fixture-protected"
+        self.add_ephemeral_candidate(protected)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+        changed = json.loads(self.state.read_text())
+        next(
+            item for item in changed if item["name"] == self.worktree_name
+        )["size_bytes"] += 1
+        self.write_projects(changed)
+        result = self.apply(check=False, protect=(protected,))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("manifest drift", result.stderr)
+        self.assertFalse(self.deleted.exists())
 
     def test_holder_opened_after_final_revalidation_stops_before_delete(self) -> None:
         self.audit()
@@ -814,6 +1031,85 @@ raise SystemExit(status)
                     result.stderr,
                 )
 
+    def test_protect_candidate_is_rejected_outside_cache_prune(self) -> None:
+        commands = (
+            "init",
+            "index",
+            "canonical",
+            "start-ui",
+            "stop-ui",
+            "status",
+            "schema",
+            "cache-audit",
+            "keepalive",
+        )
+        for command_name in commands:
+            with self.subTest(command=command_name):
+                result = self.run_script(
+                    command_name,
+                    "--protect-candidate",
+                    self.worktree_name,
+                    check=False,
+                )
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(
+                    "--protect-candidate is valid only with cache-prune",
+                    result.stderr,
+                )
+
+    def test_shell_forwards_repeated_protected_candidates_exactly(self) -> None:
+        argv_bin = self.temp / "argv-bin"
+        argv_bin.mkdir()
+        argv_file = self.temp / "python-argv"
+        fake_python = argv_bin / "python3"
+        fake_python.write_text(
+            '#!/bin/sh\nprintf "%s\\n" "$@" > "$FAKE_PYTHON_ARGV"\n'
+        )
+        fake_python.chmod(0o755)
+        environment = {
+            **self.environment,
+            "PATH": f"{argv_bin}:{self.bin}:{os.environ['PATH']}",
+            "FAKE_PYTHON_ARGV": str(argv_file),
+        }
+        result = self.run_script(
+            "cache-prune",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            "--apply",
+            "--allow-blocked-manifest",
+            "--protect-candidate",
+            "fixture-first",
+            "--protect-candidate",
+            "fixture-second",
+            env=environment,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            argv_file.read_text().splitlines(),
+            [
+                str(
+                    ROOT
+                    / "skills"
+                    / "codebase-memory-mcp"
+                    / "scripts"
+                    / "codebase_memory_cache.py"
+                ),
+                "prune",
+                "--manifest",
+                str(self.manifest),
+                "--cache-dir",
+                str(self.cache),
+                "--apply",
+                "--allow-blocked-manifest",
+                "--protect-candidate",
+                "fixture-first",
+                "--protect-candidate",
+                "fixture-second",
+            ],
+        )
+
     def test_unmapped_live_root_blocks_the_host(self) -> None:
         invalid_root = self.temp / "invalid-live-root"
         invalid_root.mkdir()
@@ -865,6 +1161,47 @@ raise SystemExit(status)
         }
         self.assertEqual(remaining, {self.main_name, name})
         self.assertTrue((self.cache / f"{name}.db").exists())
+
+    def test_protected_candidate_does_not_bypass_manifest_blockers(self) -> None:
+        invalid_root = self.temp / "invalid-live-root"
+        invalid_root.mkdir()
+        name = "fixture-invalid"
+        self.projects.append(
+            {
+                "name": name,
+                "root_path": str(invalid_root),
+                "size_bytes": sqlite_file(self.cache / f"{name}.db"),
+                "nodes": 1,
+                "edges": 1,
+            }
+        )
+        self.write_projects(self.projects)
+        self.audit()
+
+        blocked = self.apply(
+            check=False,
+            protect=(self.worktree_name,),
+        )
+        self.assertNotEqual(blocked.returncode, 0)
+        self.assertIn("host cache manifest is blocked", blocked.stderr)
+        self.assertFalse(self.deleted.exists())
+
+        allowed = self.run_script(
+            "cache-prune",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            "--allow-blocked-manifest",
+            "--protect-candidate",
+            self.worktree_name,
+        )
+        payload = json.loads(allowed.stdout)
+        self.assertEqual(payload["eligible_candidates"], 0)
+        self.assertEqual(
+            [item["name"] for item in payload["runtime_protected"]],
+            [self.worktree_name],
+        )
 
     def test_malformed_manifest_relationships_are_rejected(self) -> None:
         mutations = {

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -620,6 +620,65 @@ raise SystemExit(status)
                 self.assertIn(message, result.stderr)
                 self.assertFalse(self.deleted.exists())
 
+    def test_protected_candidates_follow_manifest_order(self) -> None:
+        first_name = "fixture-a-protected"
+        last_name = "fixture-z-protected"
+        first_root = self.add_ephemeral_candidate(first_name)
+        last_root = self.add_ephemeral_candidate(last_name)
+        self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+
+        dry_run = self.run_script(
+            "cache-prune",
+            "--manifest",
+            str(self.manifest),
+            "--cache-dir",
+            str(self.cache),
+            "--protect-candidate",
+            last_name,
+            "--protect-candidate",
+            first_name,
+        )
+        payload = json.loads(dry_run.stdout)
+        self.assertEqual(
+            [item["name"] for item in payload["runtime_protected"]],
+            [first_name, last_name],
+        )
+
+        first_root.mkdir(parents=True)
+        last_root.mkdir(parents=True)
+        applied = self.apply(
+            check=False,
+            protect=(last_name, first_name),
+        )
+        self.assertNotEqual(applied.returncode, 0)
+        self.assertIn(first_name, applied.stderr)
+        self.assertNotIn(last_name, applied.stderr)
+        self.assertFalse(self.deleted.exists())
+
+    def test_all_candidates_can_be_protected_on_apply(self) -> None:
+        self.audit()
+        before_projects = self.state.read_text()
+        database = self.cache / f"{self.worktree_name}.db"
+        before_cache = CBM.cache_fingerprint(database)
+
+        applied = self.apply(protect=(self.worktree_name,))
+        payload = json.loads(applied.stdout)
+
+        self.assertTrue(payload["applied"])
+        self.assertEqual(payload["eligible_candidates"], 0)
+        self.assertEqual(payload["eligible_candidate_bytes"], 0)
+        self.assertEqual(payload["preflighted"], 0)
+        self.assertEqual(payload["preflighted_bytes"], 0)
+        self.assertEqual(payload["deleted"], [])
+        self.assertEqual(payload["deleted_bytes"], 0)
+        self.assertEqual(
+            [item["name"] for item in payload["runtime_protected"]],
+            [self.worktree_name],
+        )
+        self.assertEqual(self.state.read_text(), before_projects)
+        self.assertEqual(CBM.cache_fingerprint(database), before_cache)
+        self.assertFalse(self.deleted.exists())
+
     def test_protected_corrupt_candidate_leaves_exact_data_untouched(self) -> None:
         corrupt_name = "fixture-a-corrupt"
         clean_name = "fixture-z-clean"


### PR DESCRIPTION
## What changed

- add repeatable prune-only `--protect-candidate NAME` support through the shell helper and Python CLI
- reject duplicate, unknown, and non-candidate names before preflight
- revalidate every runtime protected candidate while excluding only its DB integrity check and deletion
- retain protected candidates in the expected snapshot and leave their registry, DB, WAL, and SHM data untouched
- report manifest, eligible, preflighted, and runtime protected counts, reasons, and bytes in dry-run and apply output

## Why

Operators sometimes need to retain one exact reviewed candidate while pruning other independent candidates. This keeps strict snapshot, classification, canonical mapping, blocker, and eligible-candidate safety rules intact without weakening the default path.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.codebase_memory_cache_test` (46 tests)
- `make validate`
- `make marketplace && make releases-index`
- `make check-generated`
- `PYTHONDONTWRITEBYTECODE=1 pre-commit run --all-files`
- `shellcheck skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh`
- `git diff --check`

## Notes

- `--allow-blocked-manifest` remains independently required for blocked manifests
- eligible holder, WAL, canonical mapping, clone-health, and snapshot failures still stop before deletion
- regenerated indexes produced no tracked changes
