### PR TITLE
fix(codebase-memory): support fleet Python 3.9

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  codebase-memory-python39:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.9"
+
+      - name: Codebase memory cache tests
+        run: python -m unittest -v tests/codebase_memory_cache_test.py
+
   validate-and-publish-readiness:
     runs-on: ubuntu-latest
     steps:

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -709,7 +709,7 @@ def holder_inventory(
     for candidate in candidates:
         database = db_path(cache_dir, candidate["name"])
         baseline = fingerprints[candidate["name"]]
-        for kind, path in zip(kinds, cache_paths(database), strict=True):
+        for kind, path in zip(kinds, cache_paths(database)):
             if baseline[path.name] is not None:
                 inventory.append(
                     {

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -709,7 +709,13 @@ def holder_inventory(
     for candidate in candidates:
         database = db_path(cache_dir, candidate["name"])
         baseline = fingerprints[candidate["name"]]
-        for kind, path in zip(kinds, cache_paths(database)):
+        paths = cache_paths(database)
+        if len(paths) != len(kinds):
+            raise SafetyError(
+                f"project cache path invariant failed for {candidate['name']}: "
+                f"expected {len(kinds)} paths, got {len(paths)}"
+            )
+        for kind, path in zip(kinds, paths):
             if baseline[path.name] is not None:
                 inventory.append(
                     {

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -303,6 +303,64 @@ class HolderSweepTests(unittest.TestCase):
                 [("fixture-z", "db"), ("fixture-z", "wal")],
             )
 
+    def test_cache_path_count_mismatch_fails_before_external_operations(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            cache = pathlib.Path(directory)
+            database = cache / "fixture.db"
+            candidate = {"name": "fixture", "size_bytes": 1}
+            baseline = {
+                database.name: {"size": 1},
+                f"{database.name}-wal": None,
+                f"{database.name}-shm": None,
+            }
+            path_counts = {
+                "shorter": [database, pathlib.Path(f"{database}-wal")],
+                "longer": [
+                    database,
+                    pathlib.Path(f"{database}-wal"),
+                    pathlib.Path(f"{database}-shm"),
+                    pathlib.Path(f"{database}-extra"),
+                ],
+            }
+            for name, paths in path_counts.items():
+                with (
+                    self.subTest(name=name),
+                    mock.patch.object(CBM, "list_projects", return_value=[]),
+                    mock.patch.object(CBM, "validate_snapshot"),
+                    mock.patch.object(CBM, "revalidate_candidate"),
+                    mock.patch.object(
+                        CBM,
+                        "capture_cache_baseline",
+                        return_value=baseline,
+                    ),
+                    mock.patch.object(CBM, "cache_paths", return_value=paths),
+                    mock.patch.object(
+                        CBM,
+                        "lsof_binary",
+                        return_value="/usr/sbin/lsof",
+                    ),
+                    mock.patch.object(CBM, "run_holder_sweep") as holder_sweep,
+                    mock.patch.object(CBM, "validate_database") as sqlite_check,
+                    mock.patch.object(CBM.subprocess, "Popen") as delete_process,
+                    self.assertRaisesRegex(
+                        CBM.SafetyError,
+                        f"expected 3 paths, got {len(paths)}",
+                    ),
+                ):
+                    CBM.preflight_candidates(
+                        binary="codebase-memory-mcp",
+                        cache_dir=cache,
+                        candidates=[candidate],
+                        expected_snapshot=[],
+                        prefixes=[],
+                        lsof_timeout_seconds=300,
+                    )
+                holder_sweep.assert_not_called()
+                sqlite_check.assert_not_called()
+                delete_process.assert_not_called()
+
     def test_nul_lsof_output_attributes_multiple_paths_and_pids(self) -> None:
         inventory = [
             {"candidate": "first", "kind": "db", "path": "/cache/first.db"},


### PR DESCRIPTION
## What changed

- remove the Python 3.10-only `zip(..., strict=True)` argument from the fixed three-path cache inventory
- preserve that invariant explicitly by rejecting any cache path count other than DB/WAL/SHM before external operations
- add a targeted Python 3.9 CI job for `tests/codebase_memory_cache_test.py`
- keep the existing full validation job on Python 3.11

## Why

Fleet hosts still run Python 3.9, where the `strict` keyword raises `TypeError` before cache pruning can inspect holder paths. The explicit cardinality guard retains fail-closed behavior without relying on the newer keyword.

## Validation

- Python 3.14.6: `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.codebase_memory_cache_test` (71 passed)
- Python 3.9.6: `PYTHONDONTWRITEBYTECODE=1 /usr/bin/python3 -m unittest -v tests/codebase_memory_cache_test.py` (71 passed)
- Python 3.9.6 compile and import checks
- `make validate`
- `make check-generated`
- `PYTHONDONTWRITEBYTECODE=1 pre-commit run --all-files`
- `git diff --check`
