### PR TITLE
fix(codebase-memory): enforce canonical indexing boundary

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,8 +19,11 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Codebase memory cache tests
-        run: python -m unittest -v tests/codebase_memory_cache_test.py
+      - name: Codebase memory boundary tests
+        run: >-
+          python -m unittest -v
+          tests/codebase_memory_cache_test.py
+          tests/codebase_memory_gateway_test.py
 
   validate-and-publish-readiness:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is my personal **.skills** repository for Codex, Cursor, OpenClaw and agent
 
 | Skill | What it does | Install |
 |---|---|---|
-| `codebase-memory-mcp` | Index canonical Git checkouts, operate graph discovery/UI, and audit duplicate worktree caches. | `npx skills add vincentkoc/dotskills --skill codebase-memory-mcp -y` |
+| `codebase-memory-mcp` | Index canonical Git checkouts through a guarded CLI and audit duplicate worktree caches. | `npx skills add vincentkoc/dotskills --skill codebase-memory-mcp -y` |
 | `codex-goal-mining` | Mine local or fleet Codex goal history into evidence-backed rerun suites. | `npx skills add vincentkoc/dotskills --skill codex-goal-mining -y` |
 | `codex-session-recovery` | Recover Codex and Claude tmux sessions without overwriting restore evidence. | `npx skills add vincentkoc/dotskills --skill codex-session-recovery -y` |
 | `crabpot-perf-metrics` | Interpret Crabpot and OpenClaw performance artifacts without over-reading noise. | `npx skills add vincentkoc/dotskills --skill crabpot-perf-metrics -y` |

--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -33,7 +33,7 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
    - Independent roots under `~/.codex/worktrees`, `~/GIT/_Worktrees`, any `.worktrees` component, `/tmp`, or `/private/tmp` are never indexed. Linked worktrees under those paths may only rewrite to one existing nonreserved owner.
    - Missing, invalid, bare, ambiguous, ownerless, reserved-owner, or NUL-containing repositories fail closed.
 3. Prefer exposed MCP graph tools for discovery.
-   - The MCP `index_repository` tool is intentionally disabled because it cannot enforce the canonical indexing boundary.
+   - Installer or client configuration must separately disable the MCP `index_repository` tool because it cannot enforce the canonical indexing boundary. For Codex installs, render the private `disabled_tools` configuration accordingly.
    - When a graph is missing, run `scripts/codebase-memory-graph.sh index --repo "$(git rev-parse --show-toplevel)" --mode full`.
    - Use `search_graph`, `trace_path`, and `get_code_snippet` before broad text scans.
 4. Use the helper for CLI indexing.
@@ -41,6 +41,7 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
    - The helper always sends the canonical owning checkout to `index_repository`.
    - Use `--mode fast` for a smoke index.
    - Installer integrations render `scripts/codebase-memory-gateway.py.tmpl` with an approved pinned backend path. Replace `@@PYTHON_PATH_SHEBANG@@` with the raw absolute interpreter path and replace `@@PYTHON_PATH_JSON@@`, `@@BACKEND_PATH_JSON@@`, and `@@RESOLVER_PATH_JSON@@` with JSON string literals containing the exact absolute interpreter, backend, and `codebase_memory_cache.py` paths. The rendered gateway has no upgrade logic and uses `execve` for pass-through.
+   - The gateway guards raw CLI calls only. Zero-argument MCP stdio startup intentionally passes through to the approved backend, so the gateway is not an MCP tool-filtering proxy and does not replace the separate `disabled_tools` control.
 5. Verify the graph.
    - `codebase-memory-mcp cli list_projects`
    - `scripts/codebase-memory-graph.sh schema --repo "$(git rev-parse --show-toplevel)"`

--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-memory-mcp
-description: Resolve canonical Git checkouts, index and verify codebase-memory-mcp graphs, operate the local graph UI, and safely audit duplicate worktree caches. Use when a user mentions codebase memory MCP, search_graph, trace_path, graph UI, index_repository, worktree indexes, or oversized graph caches.
+description: Resolve canonical Git checkouts, index and verify codebase-memory-mcp graphs through the guarded CLI, and safely audit duplicate worktree caches. Use when a user mentions codebase memory MCP, search_graph, trace_path, index_repository, worktree indexes, or oversized graph caches.
 license: MIT
 metadata:
   source: "https://github.com/vincentkoc/dotskills"
@@ -15,7 +15,6 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
 ## When to use
 
 - Initialize, re-index, refresh, or troubleshoot a repository graph.
-- Start or inspect the local graph UI.
 - Use `search_graph`, `trace_path`, `get_code_snippet`, or `query_graph`.
 - Verify that a repository is indexed before graph-backed exploration.
 - Audit or prune duplicate linked-worktree indexes without deleting cache files directly.
@@ -31,21 +30,24 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
    - `scripts/codebase-memory-graph.sh canonical --repo "$(git rev-parse --show-toplevel)"`
    - Linked worktrees resolve through their absolute Git common directory to the one checkout that owns it.
    - Separate clones remain separate projects.
-   - Missing, invalid, bare, or ownerless repositories fail closed.
+   - Independent roots under `~/.codex/worktrees`, `~/GIT/_Worktrees`, any `.worktrees` component, `/tmp`, or `/private/tmp` are never indexed. Linked worktrees under those paths may only rewrite to one existing nonreserved owner.
+   - Missing, invalid, bare, ambiguous, ownerless, reserved-owner, or NUL-containing repositories fail closed.
 3. Prefer exposed MCP graph tools for discovery.
-   - Run `index_repository` before searching when the repository is not indexed.
+   - The MCP `index_repository` tool is intentionally disabled because it cannot enforce the canonical indexing boundary.
+   - When a graph is missing, run `scripts/codebase-memory-graph.sh index --repo "$(git rev-parse --show-toplevel)" --mode full`.
    - Use `search_graph`, `trace_path`, and `get_code_snippet` before broad text scans.
-4. Use the helper when CLI or UI orchestration is needed.
+4. Use the helper for CLI indexing.
    - `scripts/codebase-memory-graph.sh init --repo "$(git rev-parse --show-toplevel)" --mode full`
    - The helper always sends the canonical owning checkout to `index_repository`.
    - Use `--mode fast` for a smoke index.
+   - Installer integrations render `scripts/codebase-memory-gateway.py.tmpl` with an approved pinned backend path. Replace `@@PYTHON_PATH_SHEBANG@@` with the raw absolute interpreter path and replace `@@PYTHON_PATH_JSON@@`, `@@BACKEND_PATH_JSON@@`, and `@@RESOLVER_PATH_JSON@@` with JSON string literals containing the exact absolute interpreter, backend, and `codebase_memory_cache.py` paths. The rendered gateway has no upgrade logic and uses `execve` for pass-through.
 5. Verify the graph.
    - `codebase-memory-mcp cli list_projects`
    - `scripts/codebase-memory-graph.sh schema --repo "$(git rev-parse --show-toplevel)"`
    - Run one focused graph query before declaring success.
-6. Verify the UI when requested.
-   - Default URL: `http://127.0.0.1:9749/`.
-   - The helper creates a repository-scoped tmux keepalive session.
+6. Treat the UI as unavailable.
+   - `start-ui` and `keepalive` fail closed before configuration or process mutation.
+   - UI startup remains disabled until upstream `/api/index` canonicalization can enforce the same boundary. `status` may report an already-running grandfathered listener.
 7. Audit cache cleanup before applying it.
    - Freeze a host-specific manifest:
      `scripts/codebase-memory-graph.sh cache-audit --manifest /secure/path/cbm-cache.json`
@@ -65,7 +67,7 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
 8. Report exact proof.
    - Indexed project name.
    - Node and edge counts when available.
-   - UI URL and tmux session name.
+   - Any grandfathered UI listener reported by `status`.
    - For cleanup: manifest path and digest, manifest/eligible/preflighted candidate totals, runtime protected names/reasons/bytes, before/after project and byte totals, deleted project names, and any stop condition.
    - Missing binaries, unavailable MCP tools, or incomplete proof.
 
@@ -73,12 +75,11 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
 
 - Repository path.
 - Index mode: `fast`, `moderate`, `full`, or `cross-repo-intelligence`.
-- Optional UI port; default `9749`.
+- Optional status listener port; default `9749`.
 - For cache maintenance: a host-local manifest path, optional explicit ephemeral prefixes, and optional exact runtime protected candidate names.
 
 ## Outputs
 
 - Indexed and queryable repository graph.
-- Verified local graph UI when requested.
 - A dry-run cache manifest or guarded CLI-only deletion report.
 - Exact status, schema, and proof summary.

--- a/skills/codebase-memory-mcp/scripts/codebase-memory-gateway.py.tmpl
+++ b/skills/codebase-memory-mcp/scripts/codebase-memory-gateway.py.tmpl
@@ -1,0 +1,179 @@
+#!@@PYTHON_PATH_SHEBANG@@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+
+PYTHON_PATH = @@PYTHON_PATH_JSON@@
+BACKEND_PATH = @@BACKEND_PATH_JSON@@
+RESOLVER_PATH = @@RESOLVER_PATH_JSON@@
+RESOLVER_TIMEOUT_SECONDS = 60
+SAFE_CONFIG_SET = {
+    ("config", "set", "auto_index", "false"),
+    ("config", "set", "ui", "false"),
+}
+
+
+class GatewayError(RuntimeError):
+    pass
+
+
+def rendered_path(value: Any, label: str, *, executable: bool) -> str:
+    if not isinstance(value, str) or not value or "\0" in value:
+        raise GatewayError(f"invalid rendered {label} path")
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        raise GatewayError(f"rendered {label} path is not absolute: {value}")
+    if not path.is_file():
+        raise GatewayError(f"rendered {label} path is missing: {value}")
+    if executable and not os.access(path, os.X_OK):
+        raise GatewayError(f"rendered {label} path is not executable: {value}")
+    return value
+
+
+def reject_constant(value: str) -> None:
+    raise GatewayError(f"JSON constant is not allowed: {value}")
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise GatewayError(f"duplicate JSON key: {key}")
+        payload[key] = value
+    return payload
+
+
+def strict_json_object(raw: str, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(
+            raw,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_constant,
+        )
+    except (json.JSONDecodeError, UnicodeError) as error:
+        raise GatewayError(f"invalid {label} JSON: {error}") from error
+    if not isinstance(payload, dict):
+        raise GatewayError(f"{label} JSON must be one object")
+    return payload
+
+
+def denied_command(args: list[str]) -> str | None:
+    if args and args[0] in {"install", "update", "uninstall"}:
+        return f"top-level {args[0]} is disabled"
+    if args[:2] == ["config", "reset"]:
+        return "config reset is disabled"
+    if args[:2] == ["config", "set"]:
+        if tuple(args) in SAFE_CONFIG_SET:
+            return None
+        return "config set is not in the safe allowlist"
+    for argument in args:
+        if argument == "--ui" or argument.startswith("--ui="):
+            return "UI enablement is disabled"
+    return None
+
+
+def resolve_index_path(
+    python_path: str,
+    resolver_path: str,
+    repo_path: str,
+) -> str:
+    try:
+        result = subprocess.run(
+            [python_path, resolver_path, "resolve-index", repo_path],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=RESOLVER_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise GatewayError("canonical resolver timed out") from error
+    except OSError as error:
+        raise GatewayError(
+            f"canonical resolver failed to start: {error}"
+        ) from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or (
+            f"exit {result.returncode}"
+        )
+        raise GatewayError(f"canonical resolver denied repository: {detail}")
+    resolved = strict_json_object(result.stdout, "resolver response")
+    canonical = resolved.get("canonical_root")
+    if (
+        not isinstance(canonical, str)
+        or not canonical
+        or "\0" in canonical
+        or not pathlib.Path(canonical).is_absolute()
+    ):
+        raise GatewayError("resolver returned an invalid canonical_root")
+    return canonical
+
+
+def exec_backend(backend_path: str, args: list[str]) -> None:
+    try:
+        os.execve(
+            backend_path,
+            [backend_path, *args],
+            os.environ.copy(),
+        )
+    except OSError as error:
+        raise GatewayError(f"backend exec failed: {error}") from error
+
+
+def main() -> int:
+    python_path = rendered_path(PYTHON_PATH, "Python", executable=True)
+    backend_path = rendered_path(BACKEND_PATH, "backend", executable=True)
+    resolver_path = rendered_path(RESOLVER_PATH, "resolver", executable=False)
+    args = sys.argv[1:]
+
+    if args[:2] == ["cli", "index_repository"]:
+        if len(args) != 3:
+            raise GatewayError(
+                "index_repository requires exactly one JSON object argument"
+            )
+        payload = strict_json_object(args[2], "index_repository payload")
+        repo_path = payload.get("repo_path")
+        if not isinstance(repo_path, str) or not repo_path or "\0" in repo_path:
+            raise GatewayError(
+                "index_repository repo_path must be a non-empty NUL-free string"
+            )
+        payload["repo_path"] = resolve_index_path(
+            python_path,
+            resolver_path,
+            repo_path,
+        )
+        try:
+            encoded = json.dumps(
+                payload,
+                ensure_ascii=True,
+                allow_nan=False,
+                separators=(",", ":"),
+            )
+        except (TypeError, ValueError) as error:
+            raise GatewayError(
+                f"index_repository payload cannot be encoded: {error}"
+            ) from error
+        exec_backend(
+            backend_path,
+            ["cli", "index_repository", encoded],
+        )
+        raise AssertionError("backend exec returned")
+
+    reason = denied_command(args)
+    if reason is not None:
+        raise GatewayError(reason)
+    exec_backend(backend_path, args)
+    raise AssertionError("backend exec returned")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except GatewayError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2)

--- a/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
+++ b/skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh
@@ -6,18 +6,18 @@ usage() {
 Usage: codebase-memory-graph.sh <command> [options]
 
 Commands:
-  init       Configure UI, index the repo, start UI, and run a schema smoke check
+  init       Index the canonical repo and run a schema smoke check
   index      Index the repo
   canonical  Print the canonical owning checkout used for indexing
-  start-ui   Start the tmux keepalive that exposes the HTTP graph UI
+  start-ui   Fail closed while upstream UI indexing is unsafe
   stop-ui    Stop the tmux keepalive session for the repo
-  status     Show config, projects, and UI listener state
+  status     Show config, projects, and any grandfathered UI listener state
   schema     Print graph schema for the repo's indexed project
   cache-audit
              Write a guarded duplicate/dead-root cache manifest without deleting
   cache-prune
              Validate a cache manifest; add --apply to delete through the CLI
-  keepalive  Internal command used inside tmux
+  keepalive  Disabled internal UI command
 
 Options:
   --repo PATH     Repository root. Defaults to git root or current directory.
@@ -144,7 +144,7 @@ resolve_repo() {
   if [[ -z "$requested" ]]; then
     requested="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   fi
-  resolved="$(python3 "$(cache_helper)" resolve "$requested")"
+  resolved="$(python3 "$(cache_helper)" resolve-index "$requested")"
   RESOLVED_JSON="$resolved" python3 - <<'PY'
 import json
 import os
@@ -198,63 +198,13 @@ session_for_repo() {
   printf 'cbm-%s-ui\n' "${safe:-repo}"
 }
 
-configure_ui() {
-  codebase-memory-mcp config set ui true
-  codebase-memory-mcp config set port "$port"
-}
-
-wait_for_ui() {
-  local url="http://127.0.0.1:${port}/"
-  for _ in $(seq 1 20); do
-    if curl -fsS -I "$url" >/dev/null 2>&1; then
-      printf 'ui_url=%s\n' "$url"
-      return 0
-    fi
-    sleep 0.5
-  done
-  printf 'UI did not answer at %s\n' "$url" >&2
-  return 1
+ui_unavailable() {
+  printf 'codebase-memory-mcp UI startup is disabled until upstream /api/index canonicalization is available\n' >&2
+  exit 2
 }
 
 cmd_keepalive() {
-  need node
-  CBM_UI_PORT="$port" exec node <<'NODE'
-const { spawn } = require("child_process");
-
-const port = process.env.CBM_UI_PORT || "9749";
-const child = spawn("codebase-memory-mcp", ["--ui=true", `--port=${port}`], {
-  stdio: ["pipe", "pipe", "pipe"],
-});
-
-child.stdout.on("data", () => {});
-child.stderr.on("data", (chunk) => process.stderr.write(chunk));
-
-child.stdin.write(JSON.stringify({
-  jsonrpc: "2.0",
-  id: 1,
-  method: "initialize",
-  params: {
-    protocolVersion: "2024-11-05",
-    capabilities: {},
-    clientInfo: {
-      name: "codebase-memory-graph-ui-keepalive",
-      version: "1",
-    },
-  },
-}) + "\n");
-child.stdin.write(JSON.stringify({
-  jsonrpc: "2.0",
-  method: "notifications/initialized",
-  params: {},
-}) + "\n");
-
-child.on("exit", (code, signal) => {
-  process.exit(code ?? (signal ? 1 : 0));
-});
-process.on("SIGTERM", () => child.kill("SIGTERM"));
-process.on("SIGINT", () => child.kill("SIGINT"));
-setInterval(() => {}, 2147483647);
-NODE
+  ui_unavailable
 }
 
 cmd_index() {
@@ -320,20 +270,7 @@ cmd_cache_prune() {
 }
 
 cmd_start_ui() {
-  local root session script keepalive_cmd
-  need codebase-memory-mcp
-  need tmux
-  need curl
-  configure_ui
-  root="$(resolve_repo)"
-  session="$(session_for_repo "$root")"
-  script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
-  if ! tmux has-session -t "$session" 2>/dev/null; then
-    printf -v keepalive_cmd '%q ' "$script" keepalive --port "$port"
-    tmux new-session -d -s "$session" "$keepalive_cmd"
-  fi
-  printf 'tmux_session=%s\n' "$session"
-  wait_for_ui
+  ui_unavailable
 }
 
 cmd_stop_ui() {
@@ -380,9 +317,7 @@ cmd_status() {
 cmd_init() {
   need codebase-memory-mcp
   need python3
-  configure_ui
   cmd_index
-  cmd_start_ui
   cmd_schema >/dev/null
   cmd_status
 }

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -22,6 +22,7 @@ from typing import Any
 
 
 SCHEMA_VERSION = 1
+GIT_TIMEOUT_SECONDS = 30
 LSOF_ARGV_BUDGET = 128 * 1024
 LSOF_PATH = "/usr/sbin/lsof"
 LSOF_TIMEOUT_SECONDS = 300
@@ -61,14 +62,21 @@ def run(
     *,
     check: bool = True,
     env: dict[str, str] | None = None,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(
-        command,
-        check=False,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise SafetyError(
+            f"{' '.join(command[:3])}: timed out after {timeout} seconds"
+        ) from error
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise SafetyError(f"{' '.join(command[:3])}: {detail}")
@@ -89,7 +97,11 @@ def git_env() -> dict[str, str]:
 
 
 def git(path: pathlib.Path, *args: str) -> str:
-    return run(["git", "-C", str(path), *args], env=git_env()).stdout.strip()
+    return run(
+        ["git", "-C", str(path), *args],
+        env=git_env(),
+        timeout=GIT_TIMEOUT_SECONDS,
+    ).stdout.strip()
 
 
 def absolute_git_path(root: pathlib.Path, option: str) -> pathlib.Path:
@@ -97,6 +109,7 @@ def absolute_git_path(root: pathlib.Path, option: str) -> pathlib.Path:
         ["git", "-C", str(root), "rev-parse", "--path-format=absolute", option],
         check=False,
         env=git_env(),
+        timeout=GIT_TIMEOUT_SECONDS,
     )
     if result.returncode == 0:
         return pathlib.Path(result.stdout.strip()).resolve()
@@ -107,16 +120,30 @@ def absolute_git_path(root: pathlib.Path, option: str) -> pathlib.Path:
     return path.resolve()
 
 
-def worktree_paths(root: pathlib.Path) -> list[pathlib.Path]:
+def lexical_absolute_path(path: str | os.PathLike[str]) -> pathlib.Path:
+    raw = os.fspath(path)
+    if "\0" in raw:
+        raise SafetyError("repository path contains NUL")
+    return pathlib.Path(os.path.abspath(os.path.expanduser(raw)))
+
+
+def worktree_entries(root: pathlib.Path) -> list[dict[str, pathlib.Path]]:
     result = run(
         ["git", "-C", str(root), "worktree", "list", "--porcelain", "-z"],
         env=git_env(),
+        timeout=GIT_TIMEOUT_SECONDS,
     )
-    paths: list[pathlib.Path] = []
+    entries: list[dict[str, pathlib.Path]] = []
     for field in result.stdout.split("\0"):
         if field.startswith("worktree "):
-            paths.append(pathlib.Path(field.removeprefix("worktree ")).resolve())
-    return paths
+            lexical = lexical_absolute_path(field.removeprefix("worktree "))
+            try:
+                resolved = lexical.resolve(strict=True)
+            except (OSError, RuntimeError):
+                continue
+            if resolved.is_dir():
+                entries.append({"lexical": lexical, "resolved": resolved})
+    return entries
 
 
 def clone_health(root: pathlib.Path) -> dict[str, Any]:
@@ -126,6 +153,7 @@ def clone_health(root: pathlib.Path) -> dict[str, Any]:
             ["git", "-C", str(root), "config", "--bool", "--get", "remote.origin.promisor"],
             check=False,
             env=git_env(),
+            timeout=GIT_TIMEOUT_SECONDS,
         ).stdout.strip()
         == "true"
     )
@@ -133,6 +161,7 @@ def clone_health(root: pathlib.Path) -> dict[str, Any]:
         ["git", "-C", str(root), "config", "--get", "remote.origin.partialclonefilter"],
         check=False,
         env=git_env(),
+        timeout=GIT_TIMEOUT_SECONDS,
     ).stdout.strip()
     return {
         "shallow": shallow,
@@ -142,44 +171,71 @@ def clone_health(root: pathlib.Path) -> dict[str, Any]:
     }
 
 
-def resolve_repository(path: str | os.PathLike[str]) -> dict[str, Any]:
-    requested = pathlib.Path(path).expanduser()
-    if not requested.exists() or not requested.is_dir():
-        raise SafetyError(f"repository path is missing or not a directory: {requested}")
-    requested = requested.resolve()
+def resolve_repository_details(
+    path: str | os.PathLike[str],
+) -> dict[str, Any]:
+    requested_lexical = lexical_absolute_path(path)
+    if not requested_lexical.exists() or not requested_lexical.is_dir():
+        raise SafetyError(
+            f"repository path is missing or not a directory: {requested_lexical}"
+        )
+    try:
+        requested = requested_lexical.resolve(strict=True)
+    except (OSError, RuntimeError) as error:
+        raise SafetyError(
+            f"cannot resolve repository path: {requested_lexical}: {error}"
+        ) from error
     if git(requested, "rev-parse", "--is-inside-work-tree") != "true":
         raise SafetyError(f"not a Git worktree: {requested}")
     if git(requested, "rev-parse", "--is-bare-repository") == "true":
         raise SafetyError(f"bare repositories are not indexable: {requested}")
 
-    root = pathlib.Path(git(requested, "rev-parse", "--show-toplevel")).resolve()
+    root_lexical = lexical_absolute_path(
+        git(requested, "rev-parse", "--show-toplevel")
+    )
+    root = root_lexical.resolve(strict=True)
     common_dir = absolute_git_path(root, "--git-common-dir")
     git_dir = absolute_git_path(root, "--git-dir")
     canonical = root
+    canonical_lexical = root_lexical
 
     if git_dir != common_dir:
-        owners: list[pathlib.Path] = []
-        for candidate in worktree_paths(root):
-            if not candidate.is_dir():
-                continue
+        owners: list[dict[str, pathlib.Path]] = []
+        for entry in worktree_entries(root):
+            candidate = entry["resolved"]
             try:
-                candidate_root = pathlib.Path(
+                candidate_root_lexical = lexical_absolute_path(
                     git(candidate, "rev-parse", "--show-toplevel")
-                ).resolve()
+                )
+                candidate_root = candidate_root_lexical.resolve(strict=True)
                 candidate_git_dir = absolute_git_path(candidate_root, "--git-dir")
                 candidate_common_dir = absolute_git_path(
                     candidate_root, "--git-common-dir"
                 )
             except SafetyError:
                 continue
-            if candidate_git_dir == common_dir and candidate_common_dir == common_dir:
-                owners.append(candidate_root)
-        owners = sorted(set(owners))
+            if (
+                candidate_root == candidate
+                and candidate_git_dir == common_dir
+                and candidate_common_dir == common_dir
+            ):
+                owners.append(
+                    {
+                        "lexical": entry["lexical"],
+                        "resolved": candidate_root,
+                    }
+                )
+        unique_owners = {
+            (str(owner["lexical"]), str(owner["resolved"])): owner
+            for owner in owners
+        }
+        owners = [unique_owners[key] for key in sorted(unique_owners)]
         if len(owners) != 1:
             raise SafetyError(
                 f"cannot identify one owning checkout for Git common dir {common_dir}"
             )
-        canonical = owners[0]
+        canonical_lexical = owners[0]["lexical"]
+        canonical = owners[0]["resolved"]
 
     if not canonical.is_dir():
         raise SafetyError(f"owning checkout is missing: {canonical}")
@@ -191,14 +247,96 @@ def resolve_repository(path: str | os.PathLike[str]) -> dict[str, Any]:
         raise SafetyError(f"owning checkout does not own Git common dir: {canonical}")
 
     return {
-        "requested": str(requested),
-        "root": str(root),
-        "canonical_root": str(canonical),
-        "common_dir": str(common_dir),
-        "git_dir": str(git_dir),
+        "requested_lexical": requested_lexical,
+        "requested": requested,
+        "root_lexical": root_lexical,
+        "root": root,
+        "canonical_lexical": canonical_lexical,
+        "canonical_root": canonical,
+        "common_dir": common_dir,
+        "git_dir": git_dir,
         "linked_worktree": root != canonical,
         "clone": clone_health(canonical),
     }
+
+
+def public_repository_resolution(details: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "requested": str(details["requested"]),
+        "root": str(details["root"]),
+        "canonical_root": str(details["canonical_root"]),
+        "common_dir": str(details["common_dir"]),
+        "git_dir": str(details["git_dir"]),
+        "linked_worktree": details["linked_worktree"],
+        "clone": details["clone"],
+    }
+
+
+def resolve_repository(path: str | os.PathLike[str]) -> dict[str, Any]:
+    return public_repository_resolution(resolve_repository_details(path))
+
+
+def path_is_within_lexical(path: pathlib.Path, prefix: pathlib.Path) -> bool:
+    try:
+        path.relative_to(prefix)
+        return True
+    except ValueError:
+        return False
+
+
+def reserved_index_path(
+    path: pathlib.Path,
+    *,
+    home: pathlib.Path,
+    platform: str,
+) -> bool:
+    home_lexical = lexical_absolute_path(home)
+    home_resolved = home_lexical.resolve(strict=False)
+    prefixes = (
+        home_lexical / ".codex" / "worktrees",
+        home_lexical / "GIT" / "_Worktrees",
+        home_resolved / ".codex" / "worktrees",
+        home_resolved / "GIT" / "_Worktrees",
+        pathlib.Path("/tmp"),
+        pathlib.Path("/private/tmp"),
+    )
+    if any(path_is_within_lexical(path, prefix) for prefix in prefixes):
+        return True
+    for part in path.parts[1:]:
+        if platform == "darwin":
+            if part.casefold() == ".worktrees":
+                return True
+        elif part == ".worktrees":
+            return True
+    return False
+
+
+def resolve_index_repository(
+    path: str | os.PathLike[str],
+    *,
+    home: pathlib.Path | None = None,
+    platform: str | None = None,
+) -> dict[str, Any]:
+    details = resolve_repository_details(path)
+    home = pathlib.Path.home() if home is None else home
+    platform = sys.platform if platform is None else platform
+    guarded = [
+        ("owning checkout lexical path", details["canonical_lexical"]),
+        ("owning checkout resolved path", details["canonical_root"]),
+    ]
+    if not details["linked_worktree"]:
+        guarded.extend(
+            [
+                ("requested lexical path", details["requested_lexical"]),
+                ("requested resolved path", details["requested"]),
+                ("repository lexical root", details["root_lexical"]),
+                ("repository resolved root", details["root"]),
+            ]
+        )
+    for label, candidate in guarded:
+        if reserved_index_path(candidate, home=home, platform=platform):
+            raise SafetyError(f"{label} is reserved for indexing: {candidate}")
+    return public_repository_resolution(details)
 
 
 def cbm_cache_dir(value: str | None) -> pathlib.Path:
@@ -1705,6 +1843,9 @@ def parser() -> argparse.ArgumentParser:
     resolve = subparsers.add_parser("resolve")
     resolve.add_argument("repo")
 
+    resolve_index = subparsers.add_parser("resolve-index")
+    resolve_index.add_argument("repo")
+
     audit_parser = subparsers.add_parser("audit")
     audit_parser.add_argument("--manifest", required=True)
     audit_parser.add_argument("--ephemeral-prefix", action="append", default=[])
@@ -1732,13 +1873,16 @@ def main() -> int:
         if args.command == "resolve":
             print(json.dumps(resolve_repository(args.repo), sort_keys=True))
             return 0
+        if args.command == "resolve-index":
+            print(json.dumps(resolve_index_repository(args.repo), sort_keys=True))
+            return 0
         if args.command == "audit":
             return audit(args)
         if args.command == "prune":
             return prune(args)
     except SafetyError as error:
         print(f"error: {error}", file=sys.stderr)
-        return 1
+        return 2 if args.command == "resolve-index" else 1
     raise AssertionError(args.command)
 
 

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -126,6 +126,278 @@ class ResolverTests(unittest.TestCase):
                     with self.assertRaises(CBM.SafetyError):
                         CBM.resolve_repository(path)
 
+    def test_resolve_index_rewrites_reserved_linked_worktree_and_subdir(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            home = temp / "home"
+            home.mkdir()
+            owner = temp / "owner"
+            linked = home / ".codex" / "worktrees" / "feature"
+            linked.parent.mkdir(parents=True)
+            init_repo(owner)
+            command(
+                "git",
+                "-C",
+                str(owner),
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "feature",
+                str(linked),
+            )
+            subdir = linked / "nested"
+            subdir.mkdir()
+
+            for requested in (linked, subdir):
+                with self.subTest(requested=requested):
+                    result = CBM.resolve_index_repository(
+                        requested,
+                        home=home,
+                        platform="darwin",
+                    )
+                    self.assertEqual(
+                        result["canonical_root"],
+                        str(owner.resolve()),
+                    )
+                    self.assertTrue(result["linked_worktree"])
+
+    def test_resolve_index_rejects_reserved_independent_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            home = temp / "home"
+            home.mkdir()
+            cases = (
+                home / ".codex" / "worktrees" / "repo",
+                home / "GIT" / "_Worktrees" / "repo",
+                temp / "project-lower" / ".worktrees" / "repo",
+                temp / "project-mixed" / ".WorkTrees" / "repo",
+            )
+            for repo in cases:
+                repo.parent.mkdir(parents=True, exist_ok=True)
+                init_repo(repo)
+                with self.subTest(repo=repo):
+                    with self.assertRaisesRegex(
+                        CBM.SafetyError,
+                        "reserved for indexing",
+                    ):
+                        CBM.resolve_index_repository(
+                            repo,
+                            home=home,
+                            platform="darwin",
+                        )
+
+            for reserved in (
+                pathlib.Path("/tmp/repo"),
+                pathlib.Path("/private/tmp/repo"),
+            ):
+                with self.subTest(reserved=reserved):
+                    self.assertTrue(
+                        CBM.reserved_index_path(
+                            reserved,
+                            home=home,
+                            platform="darwin",
+                        )
+                    )
+
+            with tempfile.TemporaryDirectory(
+                prefix="cbm-index-",
+                dir="/tmp",
+            ) as tmp_directory:
+                tmp_repo = pathlib.Path(tmp_directory) / "repo"
+                init_repo(tmp_repo)
+                with self.assertRaisesRegex(
+                    CBM.SafetyError,
+                    "reserved for indexing",
+                ):
+                    CBM.resolve_index_repository(
+                        tmp_repo,
+                        home=home,
+                        platform="darwin",
+                    )
+
+    def test_worktrees_component_is_case_insensitive_only_on_darwin(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            home = temp / "home"
+            candidate = temp / ".WorkTrees" / "repo"
+            self.assertTrue(
+                CBM.reserved_index_path(
+                    candidate,
+                    home=home,
+                    platform="darwin",
+                )
+            )
+            self.assertFalse(
+                CBM.reserved_index_path(
+                    candidate,
+                    home=home,
+                    platform="linux",
+                )
+            )
+
+    def test_resolve_index_rejects_reserved_owner_and_symlink_bypasses(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            home = temp / "home"
+            home.mkdir()
+
+            reserved_owner = home / ".codex" / "worktrees" / "owner"
+            reserved_owner.parent.mkdir(parents=True)
+            init_repo(reserved_owner)
+            linked = temp / "linked"
+            command(
+                "git",
+                "-C",
+                str(reserved_owner),
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "linked",
+                str(linked),
+            )
+            with self.assertRaisesRegex(
+                CBM.SafetyError,
+                "owning checkout.*reserved",
+            ):
+                CBM.resolve_index_repository(
+                    linked,
+                    home=home,
+                    platform="darwin",
+                )
+
+            safe_repo = temp / "safe-repo"
+            init_repo(safe_repo)
+            reserved_alias = home / "GIT" / "_Worktrees" / "alias"
+            reserved_alias.parent.mkdir(parents=True)
+            reserved_alias.symlink_to(safe_repo, target_is_directory=True)
+            with self.assertRaisesRegex(
+                CBM.SafetyError,
+                "requested lexical path.*reserved",
+            ):
+                CBM.resolve_index_repository(
+                    reserved_alias,
+                    home=home,
+                    platform="darwin",
+                )
+
+            independent_reserved = home / ".codex" / "worktrees" / "clone"
+            init_repo(independent_reserved)
+            safe_alias = temp / "safe-alias"
+            safe_alias.symlink_to(
+                independent_reserved,
+                target_is_directory=True,
+            )
+            with self.assertRaisesRegex(
+                CBM.SafetyError,
+                "reserved for indexing",
+            ):
+                CBM.resolve_index_repository(
+                    safe_alias,
+                    home=home,
+                    platform="darwin",
+                )
+
+    def test_resolve_index_keeps_separate_safe_clones_distinct(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            home = temp / "home"
+            first = temp / "first"
+            second = temp / "second"
+            init_repo(first)
+            command("git", "clone", "-q", str(first), str(second))
+            first_result = CBM.resolve_index_repository(first, home=home)
+            second_result = CBM.resolve_index_repository(second, home=home)
+            self.assertEqual(first_result["canonical_root"], str(first.resolve()))
+            self.assertEqual(
+                second_result["canonical_root"],
+                str(second.resolve()),
+            )
+
+    def test_resolve_index_missing_bare_invalid_ambiguous_and_nul_fail(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            home = temp / "home"
+            bare = temp / "bare.git"
+            invalid = temp / "invalid"
+            invalid.mkdir()
+            command("git", "init", "-q", "--bare", str(bare))
+            for path in (temp / "missing", bare, invalid, "bad\0path"):
+                with self.subTest(path=path):
+                    with self.assertRaises(CBM.SafetyError):
+                        CBM.resolve_index_repository(path, home=home)
+
+            owner = temp / "owner"
+            linked = temp / "linked"
+            alias = temp / "owner-alias"
+            init_repo(owner)
+            command(
+                "git",
+                "-C",
+                str(owner),
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "linked",
+                str(linked),
+            )
+            alias.symlink_to(owner, target_is_directory=True)
+            ambiguous = [
+                {"lexical": owner, "resolved": owner.resolve()},
+                {"lexical": alias, "resolved": owner.resolve()},
+            ]
+            with (
+                mock.patch.object(
+                    CBM,
+                    "worktree_entries",
+                    return_value=ambiguous,
+                ),
+                self.assertRaisesRegex(
+                    CBM.SafetyError,
+                    "cannot identify one owning checkout",
+                ),
+            ):
+                CBM.resolve_index_repository(linked, home=home)
+
+    def test_git_timeout_fails_closed(self) -> None:
+        with (
+            mock.patch.object(
+                CBM.subprocess,
+                "run",
+                side_effect=subprocess.TimeoutExpired("git", 30),
+            ),
+            self.assertRaisesRegex(
+                CBM.SafetyError,
+                "timed out after 30 seconds",
+            ),
+        ):
+            CBM.git(pathlib.Path("/repo"), "status")
+
+    def test_resolve_index_cli_denial_exits_two(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(MODULE_PATH),
+                "resolve-index",
+                "/missing/repository",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("missing or not a directory", result.stderr)
+
 
 class DatabaseValidationTests(unittest.TestCase):
     def test_uses_exact_immutable_read_only_uri(self) -> None:

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -129,7 +129,7 @@ class ResolverTests(unittest.TestCase):
     def test_resolve_index_rewrites_reserved_linked_worktree_and_subdir(
         self,
     ) -> None:
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as directory:
             temp = pathlib.Path(directory)
             home = temp / "home"
             home.mkdir()
@@ -165,7 +165,7 @@ class ResolverTests(unittest.TestCase):
                     self.assertTrue(result["linked_worktree"])
 
     def test_resolve_index_rejects_reserved_independent_roots(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as directory:
             temp = pathlib.Path(directory)
             home = temp / "home"
             home.mkdir()
@@ -221,7 +221,7 @@ class ResolverTests(unittest.TestCase):
     def test_worktrees_component_is_case_insensitive_only_on_darwin(
         self,
     ) -> None:
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as directory:
             temp = pathlib.Path(directory)
             home = temp / "home"
             candidate = temp / ".WorkTrees" / "repo"
@@ -243,7 +243,7 @@ class ResolverTests(unittest.TestCase):
     def test_resolve_index_rejects_reserved_owner_and_symlink_bypasses(
         self,
     ) -> None:
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as directory:
             temp = pathlib.Path(directory)
             home = temp / "home"
             home.mkdir()
@@ -306,7 +306,7 @@ class ResolverTests(unittest.TestCase):
                 )
 
     def test_resolve_index_keeps_separate_safe_clones_distinct(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as directory:
             temp = pathlib.Path(directory)
             home = temp / "home"
             first = temp / "first"
@@ -324,7 +324,7 @@ class ResolverTests(unittest.TestCase):
     def test_resolve_index_missing_bare_invalid_ambiguous_and_nul_fail(
         self,
     ) -> None:
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as directory:
             temp = pathlib.Path(directory)
             home = temp / "home"
             bare = temp / "bare.git"

--- a/tests/codebase_memory_gateway_test.py
+++ b/tests/codebase_memory_gateway_test.py
@@ -297,7 +297,7 @@ class GraphUiBoundaryTests(unittest.TestCase):
                     self.assertFalse(calls.exists())
 
     def test_init_does_not_enable_or_start_ui(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as directory:
             temp = pathlib.Path(directory)
             repo = temp / "repo"
             repo.mkdir()

--- a/tests/codebase_memory_gateway_test.py
+++ b/tests/codebase_memory_gateway_test.py
@@ -188,6 +188,13 @@ print(json.dumps({"canonical_root": os.environ["FAKE_CANONICAL"]}))
         )
         self.assertFalse(self.backend_log.exists())
 
+    def test_zero_arg_stdio_startup_intentionally_execs_backend(self) -> None:
+        result = self.run_gateway()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        response = json.loads(result.stdout)
+        self.assertEqual(response["argv"], [str(self.backend)])
+        self.assertFalse(self.resolver_log.exists())
+
     def test_non_index_passthrough_uses_exact_exec_pid_exit_and_signal(
         self,
     ) -> None:

--- a/tests/codebase_memory_gateway_test.py
+++ b/tests/codebase_memory_gateway_test.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+TEMPLATE = (
+    ROOT
+    / "skills"
+    / "codebase-memory-mcp"
+    / "scripts"
+    / "codebase-memory-gateway.py.tmpl"
+)
+GRAPH_SCRIPT = (
+    ROOT
+    / "skills"
+    / "codebase-memory-mcp"
+    / "scripts"
+    / "codebase-memory-graph.sh"
+)
+
+
+class GatewayTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.temp = pathlib.Path(self.temporary.name)
+        self.backend_log = self.temp / "backend.jsonl"
+        self.resolver_log = self.temp / "resolver.jsonl"
+        self.canonical = self.temp / "canonical"
+        self.canonical.mkdir()
+        self.backend = self.temp / "approved-backend"
+        self.backend.write_text(
+            f"""#!{sys.executable}
+import json
+import os
+import pathlib
+import signal
+import sys
+
+log = pathlib.Path(os.environ["FAKE_BACKEND_LOG"])
+with log.open("a") as handle:
+    handle.write(json.dumps({{"argv": sys.argv, "pid": os.getpid()}}) + "\\n")
+print(json.dumps({{"argv": sys.argv, "pid": os.getpid()}}))
+requested_signal = os.environ.get("FAKE_BACKEND_SIGNAL")
+if requested_signal:
+    os.kill(os.getpid(), int(requested_signal))
+raise SystemExit(int(os.environ.get("FAKE_BACKEND_EXIT", "0")))
+"""
+        )
+        self.backend.chmod(0o755)
+        self.resolver = self.temp / "resolver.py"
+        self.resolver.write_text(
+            """import json
+import os
+import pathlib
+import sys
+
+log = pathlib.Path(os.environ["FAKE_RESOLVER_LOG"])
+with log.open("a") as handle:
+    handle.write(json.dumps(sys.argv) + "\\n")
+if sys.argv[2] == "DENY":
+    print("reserved repository", file=sys.stderr)
+    raise SystemExit(2)
+print(json.dumps({"canonical_root": os.environ["FAKE_CANONICAL"]}))
+"""
+        )
+        self.gateway = self.temp / "codebase-memory-mcp"
+        rendered = TEMPLATE.read_text()
+        replacements = {
+            "@@PYTHON_PATH_SHEBANG@@": sys.executable,
+            "@@PYTHON_PATH_JSON@@": json.dumps(sys.executable),
+            "@@BACKEND_PATH_JSON@@": json.dumps(str(self.backend)),
+            "@@RESOLVER_PATH_JSON@@": json.dumps(str(self.resolver)),
+        }
+        for placeholder, value in replacements.items():
+            rendered = rendered.replace(placeholder, value)
+        self.assertNotIn("@@", rendered)
+        self.gateway.write_text(rendered)
+        self.gateway.chmod(0o755)
+        self.environment = {
+            **os.environ,
+            "FAKE_BACKEND_LOG": str(self.backend_log),
+            "FAKE_RESOLVER_LOG": str(self.resolver_log),
+            "FAKE_CANONICAL": str(self.canonical),
+            "PATH": str(self.temp),
+        }
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_gateway(
+        self,
+        *args: str,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(self.gateway), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env or self.environment,
+        )
+
+    @staticmethod
+    def read_json_lines(path: pathlib.Path) -> list[object]:
+        if not path.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in path.read_text().splitlines()
+            if line
+        ]
+
+    def reset_logs(self) -> None:
+        self.backend_log.unlink(missing_ok=True)
+        self.resolver_log.unlink(missing_ok=True)
+
+    def test_index_payload_preserves_keys_and_types(self) -> None:
+        payload = {
+            "repo_path": "/requested/repository",
+            "mode": "full",
+            "enabled": True,
+            "nothing": None,
+            "count": 3,
+            "ratio": 1.5,
+            "nested": {"values": [1, "two", False]},
+        }
+        result = self.run_gateway(
+            "cli",
+            "index_repository",
+            json.dumps(payload),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        backend = json.loads(result.stdout)
+        self.assertEqual(backend["argv"][0], str(self.backend))
+        forwarded = json.loads(backend["argv"][3])
+        self.assertEqual(
+            forwarded,
+            {**payload, "repo_path": str(self.canonical)},
+        )
+        self.assertEqual(
+            self.read_json_lines(self.resolver_log),
+            [[str(self.resolver), "resolve-index", payload["repo_path"]]],
+        )
+
+    def test_index_rejects_strict_json_and_argument_errors(self) -> None:
+        invalid = (
+            ("duplicate", ('{"repo_path":"/one","repo_path":"/two"}',)),
+            ("nan", ('{"repo_path":"/repo","value":NaN}',)),
+            ("malformed", ('{"repo_path":',)),
+            ("missing", ('{"mode":"full"}',)),
+            ("non-string", ('{"repo_path":3}',)),
+            ("nul", (json.dumps({"repo_path": "bad\0path"}),)),
+            ("array", ('["/repo"]',)),
+            ("missing-argument", ()),
+            ("extra-argument", ('{"repo_path":"/repo"}', "extra")),
+        )
+        for name, arguments in invalid:
+            with self.subTest(name=name):
+                self.reset_logs()
+                result = self.run_gateway(
+                    "cli",
+                    "index_repository",
+                    *arguments,
+                )
+                self.assertEqual(result.returncode, 2)
+                self.assertFalse(self.backend_log.exists())
+                self.assertFalse(self.resolver_log.exists())
+
+    def test_resolver_denial_never_reaches_backend(self) -> None:
+        result = self.run_gateway(
+            "cli",
+            "index_repository",
+            json.dumps({"repo_path": "DENY", "mode": "full"}),
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("canonical resolver denied repository", result.stderr)
+        self.assertEqual(
+            self.read_json_lines(self.resolver_log),
+            [[str(self.resolver), "resolve-index", "DENY"]],
+        )
+        self.assertFalse(self.backend_log.exists())
+
+    def test_non_index_passthrough_uses_exact_exec_pid_exit_and_signal(
+        self,
+    ) -> None:
+        process = subprocess.Popen(
+            [str(self.gateway), "cli", "list_projects"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self.environment,
+        )
+        stdout, stderr = process.communicate(timeout=10)
+        self.assertEqual(process.returncode, 0, stderr)
+        response = json.loads(stdout)
+        self.assertEqual(response["pid"], process.pid)
+        self.assertEqual(
+            response["argv"],
+            [str(self.backend), "cli", "list_projects"],
+        )
+
+        exit_environment = {
+            **self.environment,
+            "FAKE_BACKEND_EXIT": "7",
+        }
+        exited = self.run_gateway("--version", env=exit_environment)
+        self.assertEqual(exited.returncode, 7)
+
+        signal_environment = {
+            **self.environment,
+            "FAKE_BACKEND_SIGNAL": str(int(signal.SIGTERM)),
+        }
+        signaled = self.run_gateway("--version", env=signal_environment)
+        self.assertEqual(signaled.returncode, -signal.SIGTERM)
+
+    def test_mutation_and_ui_forms_are_denied_before_backend(self) -> None:
+        denied = (
+            ("install",),
+            ("update",),
+            ("uninstall",),
+            ("--ui",),
+            ("--ui=true",),
+            ("--ui=1",),
+            ("--ui=yes",),
+            ("--ui=on",),
+            ("--ui", "true"),
+            ("config", "reset"),
+            ("config", "reset", "--yes"),
+            ("config", "set", "ui", "true"),
+            ("config", "set", "ui", "1"),
+            ("config", "set", "auto_index", "true"),
+            ("config", "set", "port", "9749"),
+            ("config", "set", "ui", "false", "extra"),
+        )
+        for args in denied:
+            with self.subTest(args=args):
+                self.reset_logs()
+                result = self.run_gateway(*args)
+                self.assertEqual(result.returncode, 2)
+                self.assertFalse(self.backend_log.exists())
+                self.assertFalse(self.resolver_log.exists())
+
+        for args in (
+            ("config", "set", "ui", "false"),
+            ("config", "set", "auto_index", "false"),
+        ):
+            with self.subTest(args=args):
+                self.reset_logs()
+                result = self.run_gateway(*args)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertTrue(self.backend_log.exists())
+                self.assertFalse(self.resolver_log.exists())
+
+
+class GraphUiBoundaryTests(unittest.TestCase):
+    def test_ui_commands_fail_before_external_processes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            calls = temp / "calls"
+            bin_dir = temp / "bin"
+            bin_dir.mkdir()
+            fake = bin_dir / "codebase-memory-mcp"
+            fake.write_text(
+                '#!/bin/sh\nprintf "%s\\n" "$0 $*" >> "$CALLS"\n'
+            )
+            fake.chmod(0o755)
+            for name in ("curl", "git", "node", "python3", "tmux"):
+                (bin_dir / name).symlink_to(fake)
+            environment = {
+                **os.environ,
+                "CALLS": str(calls),
+                "PATH": f"{bin_dir}:/usr/bin:/bin",
+            }
+
+            for command in ("start-ui", "keepalive"):
+                with self.subTest(command=command):
+                    result = subprocess.run(
+                        [str(GRAPH_SCRIPT), command],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env=environment,
+                    )
+                    self.assertEqual(result.returncode, 2)
+                    self.assertIn(
+                        "/api/index canonicalization",
+                        result.stderr,
+                    )
+                    self.assertFalse(calls.exists())
+
+    def test_init_does_not_enable_or_start_ui(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = pathlib.Path(directory)
+            repo = temp / "repo"
+            repo.mkdir()
+            subprocess.run(
+                ["git", "init", "-q", "-b", "main", str(repo)],
+                check=True,
+            )
+            calls = temp / "calls.jsonl"
+            bin_dir = temp / "bin"
+            bin_dir.mkdir()
+            fake_backend = bin_dir / "codebase-memory-mcp"
+            fake_backend.write_text(
+                f"""#!{sys.executable}
+import json
+import os
+import pathlib
+import sys
+
+log = pathlib.Path(os.environ["CALLS"])
+with log.open("a") as handle:
+    handle.write(json.dumps({{"program": "codebase-memory-mcp", "args": sys.argv[1:]}}) + "\\n")
+args = sys.argv[1:]
+if args == ["cli", "list_projects"]:
+    print(json.dumps({{"projects": [{{
+        "name": "fixture",
+        "root_path": os.environ["FAKE_REPO_ROOT"],
+        "size_bytes": 1,
+    }}]}}))
+else:
+    print("{{}}")
+"""
+            )
+            fake_backend.chmod(0o755)
+            generic = bin_dir / "probe"
+            generic.write_text(
+                """#!/bin/sh
+printf '{"program":"%s","args":"%s"}\n' "$(basename "$0")" "$*" >> "$CALLS"
+exit 1
+"""
+            )
+            generic.chmod(0o755)
+            for name in ("curl", "lsof", "node", "tmux"):
+                (bin_dir / name).symlink_to(generic)
+            (bin_dir / "python3").symlink_to(sys.executable)
+            environment = {
+                **os.environ,
+                "CALLS": str(calls),
+                "FAKE_REPO_ROOT": str(repo.resolve()),
+                "PATH": f"{bin_dir}:/usr/bin:/bin",
+            }
+            result = subprocess.run(
+                [str(GRAPH_SCRIPT), "init", "--repo", str(repo)],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            events = self.read_events(calls)
+            rendered = json.dumps(events)
+            self.assertNotIn('"config", "set"', rendered)
+            self.assertNotIn("--ui", rendered)
+            self.assertNotIn("new-session", rendered)
+            self.assertFalse(
+                any(event["program"] == "node" for event in events)
+            )
+
+    @staticmethod
+    def read_events(path: pathlib.Path) -> list[dict[str, object]]:
+        return [
+            json.loads(line)
+            for line in path.read_text().splitlines()
+            if line
+        ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add strict `resolve-index` canonicalization for linked worktrees and deny independent indexes under reserved worktree/temp roots
- add an installer-rendered CLI exec gateway that canonicalizes only exact `cli index_repository <JSON>` calls, preserves payload data, and denies unsafe mutation/UI commands
- require separate installer/client `disabled_tools` control for MCP `index_repository`; zero-argument stdio startup intentionally passes through to the pinned backend
- disable helper UI startup until upstream `/api/index` canonicalization exists, while retaining status visibility for grandfathered listeners
- extend the Python 3.9 CI boundary suite and document helper-only indexing

## Gateway render contract

- `@@PYTHON_PATH_SHEBANG@@`: raw absolute Python interpreter path
- `@@PYTHON_PATH_JSON@@`: JSON string literal for the same interpreter
- `@@BACKEND_PATH_JSON@@`: JSON string literal for the approved pinned backend executable
- `@@RESOLVER_PATH_JSON@@`: JSON string literal for the exact `codebase_memory_cache.py` path

The rendered gateway contains no upgrade logic. Safe raw-CLI pass-through replaces itself with the approved backend using `os.execve`. It is not an MCP stdio proxy or tool filter.

## Validation

- default Python: 89 tests passed
- Python 3.9.6: 89 tests passed
- Linux-style `TMPDIR=/tmp` forced for both full Python suites
- Node OpenClaw batch sweep: 78 tests passed
- Codex goal report: 4 tests passed
- organization branch cleanup: 15 tests passed
- `make validate`
- `make check-generated`
- `shellcheck` and `bash -n`
- `pre-commit run --all-files`
- `git diff --check`
- public-data privacy scan

## Scope boundary

This prevents new independent indexing under reserved roots. It intentionally does not reclassify or clean up any existing reserved-root graph caches.
