### PR TITLE
fix(codebase-memory): classify reserved cache roots

### DIFF
--- a/skills/codebase-memory-mcp/SKILL.md
+++ b/skills/codebase-memory-mcp/SKILL.md
@@ -52,8 +52,10 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
 7. Audit cache cleanup before applying it.
    - Freeze a host-specific manifest:
      `scripts/codebase-memory-graph.sh cache-audit --manifest /secure/path/cbm-cache.json`
-   - Missing roots are protected unless the audit names an explicit narrow `--ephemeral-prefix`.
-   - Linked-worktree candidates require a mapped, indexed, healthy full canonical clone. Shallow, promisor, partial, missing, or ambiguous canonical graphs stay protected.
+   - Built-in reserved roots are `~/.codex/worktrees`, `~/GIT/_Worktrees`, `/tmp`, `/private/tmp`, and any exact `.worktrees` path component. The audit records normalized lexical and resolved boundary evidence; `.worktrees` component matching is case-insensitive on Darwin.
+   - Missing roots under a reserved boundary are `reserved_missing_root` candidates. Live valid graphs whose physical canonical root and Git common directory remain reserved are `reserved_live_root` candidates, including shallow, promisor, and partial clones. Dangling symlinks, bare repositories, non-Git roots, and invalid reserved mappings block as `live_root_unmapped`.
+   - Other missing roots are protected unless the audit names an explicit narrow `--ephemeral-prefix`.
+   - Reserved aliases or linked worktrees that resolve to a nonreserved owner retain duplicate cleanup rules. They require a mapped, registered, final-protected healthy full canonical graph; candidate graphs, reserved graphs, shallow/promisor/partial owners, missing alternate graphs, and ambiguous owners cannot preserve them.
    - When legacy home symlinks name the same physical checkout, preserve the exact canonical graph and treat only the symlink-named graph as a duplicate. Preserve a sole symlink-named graph.
    - Review the manifest, then dry-run it:
      `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json`
@@ -63,13 +65,14 @@ Bring up `codebase-memory-mcp` for the owning Git checkout and prove the graph i
    - Apply only the unchanged manifest:
      `scripts/codebase-memory-graph.sh cache-prune --manifest /secure/path/cbm-cache.json --apply`
    - Dry-run and apply freeze regular DB/WAL/SHM fingerprints for every eligible candidate in manifest order, rejecting a missing or size-mismatched DB, nonregular files, and nonzero WAL. Existing absolute paths are swept with `/usr/sbin/lsof -nP -F0pfn -f --` in deterministic, NUL-parsed batches before any SQLite open and again after every exact `mode=ro&immutable=1` `quick_check`; global fingerprint equality is required between phases. An absent or zero-byte WAL and a stable regular SHM are allowed. Use prune-only `--lsof-timeout-seconds SECONDS` to override the 300-second holder timeout within the guarded 30-900 range.
-   - Batch holder sweeps are point-in-time checks: a transient read-only holder between sweeps is harmless and stable fingerprints detect normal writers. Unprivileged `lsof` may not see root-owned or other-user holders, so pruning trusts the point-in-time visibility available to the cache owner; running as root provides stronger holder visibility. Apply processes eligible candidates in manifest order, at most eight per deletion batch and within the same 128 KiB path budget. Each batch revalidates the snapshot, candidate relationships, and live fingerprints, performs one holder sweep, immediately proves post-sweep equality to both live and frozen fingerprints, then launches only `codebase-memory-mcp cli delete_project` children before draining them. The batch verifies registrations and DB/WAL/SHM absence once before continuing; spawn errors, timeouts, nonzero exits, retained registrations, residue, drift, or ambiguous state stop future batches and report launched, verified-deleted, failed, and ambiguous names and bytes.
+   - Batch holder sweeps are point-in-time checks: they do not prevent a legacy index or server surface from reopening a graph after the check. Unprivileged `lsof` may not see root-owned or other-user holders, so pruning trusts the point-in-time visibility available to the cache owner; running as root provides stronger holder visibility. Apply processes eligible candidates in manifest order, at most eight per deletion batch and within the same 128 KiB path budget. Each batch revalidates the snapshot and live fingerprints, performs one holder sweep, proves post-sweep fingerprint equality, then revalidates every remaining candidate relationship immediately before the first delete child. The batch launches only `codebase-memory-mcp cli delete_project` children and verifies registrations plus DB/WAL/SHM absence before continuing; spawn errors, timeouts, nonzero exits, retained registrations, residue, drift, or ambiguous state stop future batches and report launched, verified-deleted, failed, and ambiguous names and bytes.
+   - Before applying any manifest containing `reserved_live_root`, deploy the reserved-root indexing prevention and quiesce every legacy index/server surface outside this helper. The helper reports this operational precondition but does not probe or kill processes.
    - Deletion uses `codebase-memory-mcp cli delete_project` only. Never remove project databases directly.
 8. Report exact proof.
    - Indexed project name.
    - Node and edge counts when available.
    - Any grandfathered UI listener reported by `status`.
-   - For cleanup: manifest path and digest, manifest/eligible/preflighted candidate totals, runtime protected names/reasons/bytes, before/after project and byte totals, deleted project names, and any stop condition.
+   - For cleanup: manifest path and digest, manifest/eligible/preflighted candidate totals, runtime protected names/reasons/bytes, required operational preconditions, before/after project and byte totals, deleted project names, and any stop condition.
    - Missing binaries, unavailable MCP tools, or incomplete proof.
 
 ## Inputs

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -21,7 +21,7 @@ import urllib.parse
 from typing import Any
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 GIT_TIMEOUT_SECONDS = 30
 LSOF_ARGV_BUDGET = 128 * 1024
 LSOF_PATH = "/usr/sbin/lsof"
@@ -36,6 +36,10 @@ HOST_BLOCKING_REASONS = {
     "live_root_unmapped",
     "missing_canonical_graph",
 }
+RESERVED_ROOT_OPERATIONAL_PRECONDITION = (
+    "reserved-root indexing prevention is deployed and legacy index/server "
+    "surfaces are quiescent"
+)
 
 
 class SafetyError(RuntimeError):
@@ -284,12 +288,13 @@ def path_is_within_lexical(path: pathlib.Path, prefix: pathlib.Path) -> bool:
         return False
 
 
-def reserved_index_path(
+def reserved_boundary_matches(
     path: pathlib.Path,
     *,
     home: pathlib.Path,
     platform: str,
-) -> bool:
+) -> list[dict[str, str]]:
+    normalized = lexical_absolute_path(path)
     home_lexical = lexical_absolute_path(home)
     home_resolved = home_lexical.resolve(strict=False)
     prefixes = (
@@ -300,15 +305,84 @@ def reserved_index_path(
         pathlib.Path("/tmp"),
         pathlib.Path("/private/tmp"),
     )
-    if any(path_is_within_lexical(path, prefix) for prefix in prefixes):
-        return True
-    for part in path.parts[1:]:
-        if platform == "darwin":
-            if part.casefold() == ".worktrees":
-                return True
-        elif part == ".worktrees":
-            return True
-    return False
+    matches = [
+        {
+            "boundary_kind": "prefix",
+            "boundary": str(prefix),
+        }
+        for prefix in prefixes
+        if path_is_within_lexical(normalized, prefix)
+    ]
+    for part in normalized.parts[1:]:
+        matched = (
+            part.casefold() == ".worktrees"
+            if platform == "darwin"
+            else part == ".worktrees"
+        )
+        if matched:
+            matches.append(
+                {
+                    "boundary_kind": "component",
+                    "boundary": part,
+                }
+            )
+    return sorted(matches, key=lambda item: canonical_json(item))
+
+
+def reserved_index_path(
+    path: pathlib.Path,
+    *,
+    home: pathlib.Path,
+    platform: str,
+) -> bool:
+    return bool(
+        reserved_boundary_matches(path, home=home, platform=platform)
+    )
+
+
+def reserved_path_evidence(
+    paths: list[tuple[str, pathlib.Path]],
+    *,
+    home: pathlib.Path,
+    platform: str,
+) -> list[dict[str, str]]:
+    evidence: list[dict[str, str]] = []
+    for path_kind, path in paths:
+        normalized = lexical_absolute_path(path)
+        for match in reserved_boundary_matches(
+            normalized,
+            home=home,
+            platform=platform,
+        ):
+            evidence.append(
+                {
+                    "path_kind": path_kind,
+                    "path": str(normalized),
+                    **match,
+                }
+            )
+    return sorted(evidence, key=lambda item: canonical_json(item))
+
+
+def repository_reserved_evidence(
+    *,
+    lexical_root: pathlib.Path,
+    resolved_root: pathlib.Path,
+    canonical_root: pathlib.Path,
+    common_dir: pathlib.Path,
+    home: pathlib.Path,
+    platform: str,
+) -> list[dict[str, str]]:
+    return reserved_path_evidence(
+        [
+            ("lexical_root", lexical_root),
+            ("resolved_root", resolved_root),
+            ("canonical_root", canonical_root),
+            ("common_dir", common_dir),
+        ],
+        home=home,
+        platform=platform,
+    )
 
 
 def resolve_index_repository(
@@ -448,6 +522,24 @@ def declared_root(raw: str) -> pathlib.Path | None:
     return pathlib.Path(os.path.normpath(path))
 
 
+def dangling_symlink_component(path: pathlib.Path) -> pathlib.Path | None:
+    current = pathlib.Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            return None
+        except OSError as error:
+            raise SafetyError(f"cannot inspect repository path {current}: {error}") from error
+        if stat.S_ISLNK(metadata.st_mode):
+            try:
+                current.resolve(strict=True)
+            except (OSError, RuntimeError):
+                return current
+    return None
+
+
 def symlink_components(path: pathlib.Path) -> int:
     current = pathlib.Path(path.anchor)
     count = 0
@@ -499,9 +591,16 @@ def build_manifest(
     projects: list[dict[str, Any]],
     cache_dir: pathlib.Path,
     ephemeral_prefixes: list[pathlib.Path],
+    home: pathlib.Path | None = None,
+    platform: str | None = None,
 ) -> dict[str, Any]:
-    candidates: list[dict[str, Any]] = []
-    protected: list[dict[str, Any]] = []
+    home = lexical_absolute_path(
+        pathlib.Path.home() if home is None else home
+    )
+    platform = sys.platform if platform is None else platform
+    inspections: dict[str, dict[str, Any]] = {}
+    classifications: dict[str, dict[str, Any]] = {}
+
     for project in projects:
         raw_root = project["root_path"]
         base = {
@@ -510,11 +609,66 @@ def build_manifest(
             "size_bytes": project["size_bytes"],
         }
         if not raw_root:
-            protected.append({**base, "reason": "empty_root"})
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {**base, "reason": "empty_root"},
+            }
             continue
-        root = pathlib.Path(raw_root).expanduser()
+        root = declared_root(raw_root)
+        if root is None:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **base,
+                    "reason": "live_root_unmapped",
+                    "detail": "repository root is not absolute",
+                },
+            }
+            continue
+        dangling = dangling_symlink_component(root)
+        if dangling is not None:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **base,
+                    "reason": "live_root_unmapped",
+                    "detail": f"repository path contains dangling symlink: {dangling}",
+                },
+            }
+            continue
         if not root.exists():
-            normalized = root.resolve(strict=False)
+            try:
+                normalized = root.resolve(strict=False)
+            except (OSError, RuntimeError) as error:
+                classifications[project["name"]] = {
+                    "collection": "protected",
+                    "record": {
+                        **base,
+                        "reason": "live_root_unmapped",
+                        "detail": f"cannot resolve missing repository root: {error}",
+                    },
+                }
+                continue
+            evidence = reserved_path_evidence(
+                [
+                    ("lexical_root", root),
+                    ("resolved_root", normalized),
+                ],
+                home=home,
+                platform=platform,
+            )
+            if evidence:
+                classifications[project["name"]] = {
+                    "collection": "candidates",
+                    "record": {
+                        **base,
+                        "reason": "reserved_missing_root",
+                        "lexical_root": str(root),
+                        "resolved_root": str(normalized),
+                        "reserved_boundaries": evidence,
+                    },
+                }
+                continue
             matching_prefix = next(
                 (
                     prefix
@@ -524,88 +678,243 @@ def build_manifest(
                 None,
             )
             if matching_prefix is None:
-                protected.append({**base, "reason": "missing_root_outside_prefix"})
+                classifications[project["name"]] = {
+                    "collection": "protected",
+                    "record": {
+                        **base,
+                        "reason": "missing_root_outside_prefix",
+                    },
+                }
             else:
-                candidates.append(
-                    {
+                classifications[project["name"]] = {
+                    "collection": "candidates",
+                    "record": {
                         **base,
                         "reason": "ephemeral_missing_root",
                         "ephemeral_prefix": str(matching_prefix),
-                    }
-                )
+                    },
+                }
             continue
         try:
-            resolved = resolve_repository(root)
+            details = resolve_repository_details(root)
         except SafetyError as error:
-            protected.append(
-                {**base, "reason": "live_root_unmapped", "detail": str(error)}
-            )
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **base,
+                    "reason": "live_root_unmapped",
+                    "detail": str(error),
+                },
+            }
             continue
-        canonical_root = pathlib.Path(resolved["canonical_root"])
-        canonical_project = project_for_root(projects, canonical_root)
-        if canonical_project is None:
-            protected.append(
-                {
+        try:
+            resolved_root = root.resolve(strict=True)
+        except (OSError, RuntimeError) as error:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **base,
+                    "reason": "live_root_unmapped",
+                    "detail": f"cannot resolve repository root: {error}",
+                },
+            }
+            continue
+        evidence = repository_reserved_evidence(
+            lexical_root=root,
+            resolved_root=resolved_root,
+            canonical_root=details["canonical_root"],
+            common_dir=details["common_dir"],
+            home=home,
+            platform=platform,
+        )
+        canonical_reserved = reserved_index_path(
+            details["canonical_root"],
+            home=home,
+            platform=platform,
+        )
+        common_reserved = reserved_index_path(
+            details["common_dir"],
+            home=home,
+            platform=platform,
+        )
+        inspections[project["name"]] = {
+            "project": project,
+            "base": base,
+            "root": root,
+            "resolved_root": resolved_root,
+            "details": details,
+            "reserved_boundaries": evidence,
+        }
+        if canonical_reserved and common_reserved:
+            classifications[project["name"]] = {
+                "collection": "candidates",
+                "record": {
+                    **base,
+                    "reason": "reserved_live_root",
+                    "lexical_root": str(root),
+                    "resolved_root": str(resolved_root),
+                    "reserved_boundaries": evidence,
+                    "canonical_root": str(details["canonical_root"]),
+                    "common_dir": str(details["common_dir"]),
+                },
+            }
+            continue
+        if canonical_reserved != common_reserved:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **base,
+                    "reason": "live_root_unmapped",
+                    "detail": (
+                        "canonical root and Git common dir cross the reserved "
+                        "boundary"
+                    ),
+                },
+            }
+            continue
+        canonical_root = details["canonical_root"]
+        try:
+            canonical_project = project_for_root(projects, canonical_root)
+        except SafetyError as error:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
                     **base,
                     "reason": "missing_canonical_graph",
                     "canonical_root": str(canonical_root),
-                }
-            )
+                    "detail": str(error),
+                },
+            }
+            continue
+        if canonical_project is None:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **base,
+                    "reason": "missing_canonical_graph",
+                    "canonical_root": str(canonical_root),
+                    "detail": "no registered graph maps to the canonical root",
+                },
+            }
             continue
         if canonical_project["name"] == project["name"]:
-            protected.append({**base, "reason": "canonical_root"})
-            continue
-        if pathlib.Path(resolved["root"]) == canonical_root:
-            if not resolved["clone"]["full"]:
-                protected.append(
-                    {
+            if evidence:
+                classifications[project["name"]] = {
+                    "collection": "protected",
+                    "record": {
                         **base,
-                        "reason": "canonical_clone_not_full",
+                        "reason": "missing_canonical_graph",
                         "canonical_root": str(canonical_root),
-                        "canonical_project": canonical_project["name"],
-                    }
-                )
-                continue
-            candidates.append(
-                {
-                    **base,
-                    "reason": "canonical_alias_duplicate",
-                    "canonical_root": str(canonical_root),
-                    "canonical_project": canonical_project["name"],
-                    "canonical_project_root_path": canonical_project["root_path"],
-                    "canonical_size_bytes": canonical_project["size_bytes"],
-                    "common_dir": resolved["common_dir"],
+                        "detail": (
+                            "reserved alias has no separate final-protected "
+                            "canonical graph"
+                        ),
+                    },
                 }
-            )
-            continue
-        if not resolved["clone"]["full"]:
-            protected.append(
-                {
-                    **base,
-                    "reason": "canonical_clone_not_full",
-                    "canonical_root": str(canonical_root),
-                    "canonical_project": canonical_project["name"],
+            else:
+                classifications[project["name"]] = {
+                    "collection": "protected",
+                    "record": {**base, "reason": "canonical_root"},
                 }
-            )
             continue
-        candidates.append(
-            {
+        classifications[project["name"]] = {
+            "collection": "pending_duplicate",
+            "record": {
                 **base,
-                "reason": "linked_worktree_duplicate",
+                "reason": (
+                    "canonical_alias_duplicate"
+                    if details["root"] == canonical_root
+                    else "linked_worktree_duplicate"
+                ),
+                "lexical_root": str(root),
+                "resolved_root": str(resolved_root),
+                "reserved_boundaries": evidence,
                 "canonical_root": str(canonical_root),
                 "canonical_project": canonical_project["name"],
                 "canonical_project_root_path": canonical_project["root_path"],
                 "canonical_size_bytes": canonical_project["size_bytes"],
-                "common_dir": resolved["common_dir"],
-            }
+                "common_dir": str(details["common_dir"]),
+            },
+        }
+
+    for project in projects:
+        classification = classifications[project["name"]]
+        if classification["collection"] != "pending_duplicate":
+            continue
+        record = classification["record"]
+        inspection = inspections[project["name"]]
+        target = classifications.get(record["canonical_project"])
+        target_inspection = inspections.get(record["canonical_project"])
+        target_is_final_protected = (
+            target is not None
+            and target["collection"] == "protected"
+            and target["record"].get("reason") == "canonical_root"
         )
+        if not target_is_final_protected or target_inspection is None:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **inspection["base"],
+                    "reason": "missing_canonical_graph",
+                    "canonical_root": record["canonical_root"],
+                    "detail": (
+                        "mapped canonical graph is not a final protected "
+                        "project"
+                    ),
+                },
+            }
+            continue
+        if target_inspection["reserved_boundaries"]:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **inspection["base"],
+                    "reason": "missing_canonical_graph",
+                    "canonical_root": record["canonical_root"],
+                    "detail": "reserved graphs cannot preserve another project",
+                },
+            }
+            continue
+        if not inspection["details"]["clone"]["full"]:
+            classifications[project["name"]] = {
+                "collection": "protected",
+                "record": {
+                    **inspection["base"],
+                    "reason": "canonical_clone_not_full",
+                    "canonical_root": record["canonical_root"],
+                    "canonical_project": record["canonical_project"],
+                },
+            }
+            continue
+        classifications[project["name"]]["collection"] = "candidates"
+
+    candidates = [
+        classifications[project["name"]]["record"]
+        for project in projects
+        if classifications[project["name"]]["collection"] == "candidates"
+    ]
+    protected = [
+        classifications[project["name"]]["record"]
+        for project in projects
+        if classifications[project["name"]]["collection"] == "protected"
+    ]
 
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "host": socket.gethostname(),
         "cache_dir": str(cache_dir),
+        "home": str(home),
+        "platform": platform,
         "ephemeral_prefixes": [str(prefix) for prefix in ephemeral_prefixes],
+        "operational_preconditions": (
+            [RESERVED_ROOT_OPERATIONAL_PRECONDITION]
+            if any(
+                item["reason"] == "reserved_live_root"
+                for item in candidates
+            )
+            else []
+        ),
         "snapshot": project_snapshot(projects),
         "project_bytes": sum(project["size_bytes"] for project in projects),
         "candidates": candidates,
@@ -615,6 +924,7 @@ def build_manifest(
         ],
     }
     payload["manifest_digest"] = manifest_digest(payload)
+    validate_manifest_relationships(payload)
     return payload
 
 
@@ -646,6 +956,53 @@ def load_manifest(path: pathlib.Path) -> dict[str, Any]:
 
 
 def validate_manifest_relationships(payload: dict[str, Any]) -> None:
+    expected_top_level = {
+        "schema_version",
+        "created_at",
+        "host",
+        "cache_dir",
+        "home",
+        "platform",
+        "ephemeral_prefixes",
+        "operational_preconditions",
+        "snapshot",
+        "project_bytes",
+        "candidates",
+        "protected",
+        "blockers",
+        "manifest_digest",
+    }
+    if set(payload) != expected_top_level:
+        raise SafetyError("manifest top-level fields are invalid")
+    if payload["schema_version"] != SCHEMA_VERSION:
+        raise SafetyError("unsupported manifest schema")
+    if not isinstance(payload["created_at"], str):
+        raise SafetyError("manifest created_at must be a string")
+    try:
+        created_at = dt.datetime.fromisoformat(payload["created_at"])
+    except ValueError as error:
+        raise SafetyError("manifest created_at is invalid") from error
+    if created_at.tzinfo is None:
+        raise SafetyError("manifest created_at must include a timezone")
+    for key in ("host", "cache_dir", "home", "platform", "manifest_digest"):
+        if not isinstance(payload[key], str) or not payload[key]:
+            raise SafetyError(f"manifest {key} must be a nonempty string")
+    if declared_root(payload["cache_dir"]) is None:
+        raise SafetyError("manifest cache_dir must be absolute")
+    manifest_home = declared_root(payload["home"])
+    if manifest_home is None or str(manifest_home) != payload["home"]:
+        raise SafetyError("manifest home must be a normalized absolute path")
+    if not isinstance(payload["operational_preconditions"], list) or any(
+        not isinstance(value, str)
+        for value in payload["operational_preconditions"]
+    ):
+        raise SafetyError("manifest operational preconditions are invalid")
+    if (
+        not isinstance(payload["project_bytes"], int)
+        or payload["project_bytes"] < 0
+    ):
+        raise SafetyError("manifest project_bytes must be a nonnegative integer")
+
     collections: dict[str, list[dict[str, Any]]] = {}
     for key in ("snapshot", "candidates", "protected", "blockers"):
         value = payload.get(key)
@@ -660,6 +1017,21 @@ def validate_manifest_relationships(payload: dict[str, Any]) -> None:
         not isinstance(value, str) for value in prefixes
     ):
         raise SafetyError("manifest ephemeral_prefixes must be an array of strings")
+
+    snapshot_fields = {"name", "root_path", "size_bytes"}
+    for item in collections["snapshot"]:
+        if set(item) != snapshot_fields:
+            raise SafetyError("manifest snapshot record fields are invalid")
+        if (
+            not isinstance(item["root_path"], str)
+            or not isinstance(item["size_bytes"], int)
+            or item["size_bytes"] < 0
+        ):
+            raise SafetyError("manifest snapshot record values are invalid")
+    if payload["project_bytes"] != sum(
+        item["size_bytes"] for item in collections["snapshot"]
+    ):
+        raise SafetyError("manifest project_bytes disagrees with snapshot")
 
     names: dict[str, list[str]] = {}
     for key, items in collections.items():
@@ -685,6 +1057,108 @@ def validate_manifest_relationships(payload: dict[str, Any]) -> None:
         raise SafetyError(
             "manifest candidates and protected projects do not partition the snapshot"
         )
+    expected_preconditions = (
+        [RESERVED_ROOT_OPERATIONAL_PRECONDITION]
+        if any(
+            item.get("reason") == "reserved_live_root"
+            for item in collections["candidates"]
+        )
+        else []
+    )
+    if payload["operational_preconditions"] != expected_preconditions:
+        raise SafetyError("manifest operational preconditions are invalid")
+
+    base_fields = {"name", "root_path", "size_bytes", "reason"}
+    candidate_fields = {
+        "ephemeral_missing_root": base_fields | {"ephemeral_prefix"},
+        "reserved_missing_root": base_fields
+        | {
+            "lexical_root",
+            "resolved_root",
+            "reserved_boundaries",
+        },
+        "reserved_live_root": base_fields
+        | {
+            "lexical_root",
+            "resolved_root",
+            "reserved_boundaries",
+            "canonical_root",
+            "common_dir",
+        },
+        "canonical_alias_duplicate": base_fields
+        | {
+            "lexical_root",
+            "resolved_root",
+            "reserved_boundaries",
+            "canonical_root",
+            "canonical_project",
+            "canonical_project_root_path",
+            "canonical_size_bytes",
+            "common_dir",
+        },
+        "linked_worktree_duplicate": base_fields
+        | {
+            "lexical_root",
+            "resolved_root",
+            "reserved_boundaries",
+            "canonical_root",
+            "canonical_project",
+            "canonical_project_root_path",
+            "canonical_size_bytes",
+            "common_dir",
+        },
+    }
+    protected_fields = {
+        "empty_root": base_fields,
+        "missing_root_outside_prefix": base_fields,
+        "live_root_unmapped": base_fields | {"detail"},
+        "missing_canonical_graph": base_fields | {"canonical_root", "detail"},
+        "canonical_root": base_fields,
+        "canonical_clone_not_full": base_fields
+        | {"canonical_root", "canonical_project"},
+    }
+    for collection, allowed in (
+        ("candidates", candidate_fields),
+        ("protected", protected_fields),
+    ):
+        for item in collections[collection]:
+            reason = item.get("reason")
+            if reason not in allowed:
+                raise SafetyError(
+                    f"manifest {collection} has unsupported reason: {reason}"
+                )
+            if set(item) != allowed[reason]:
+                raise SafetyError(
+                    f"manifest {collection} fields are invalid for {reason}: "
+                    f"{item['name']}"
+                )
+            if reason == "live_root_unmapped":
+                if not isinstance(item["detail"], str) or not item["detail"]:
+                    raise SafetyError(
+                        f"manifest protected detail is invalid: {item['name']}"
+                    )
+            if reason == "missing_canonical_graph":
+                if (
+                    not isinstance(item["detail"], str)
+                    or not item["detail"]
+                    or not isinstance(item["canonical_root"], str)
+                    or declared_root(item["canonical_root"]) is None
+                ):
+                    raise SafetyError(
+                        f"manifest missing canonical graph evidence is invalid: "
+                        f"{item['name']}"
+                    )
+            if reason == "canonical_clone_not_full":
+                if (
+                    not isinstance(item["canonical_project"], str)
+                    or not item["canonical_project"]
+                    or not isinstance(item["canonical_root"], str)
+                    or declared_root(item["canonical_root"]) is None
+                ):
+                    raise SafetyError(
+                        f"manifest clone-health evidence is invalid: "
+                        f"{item['name']}"
+                    )
 
     for key in ("candidates", "protected"):
         for item in collections[key]:
@@ -694,6 +1168,130 @@ def validate_manifest_relationships(payload: dict[str, Any]) -> None:
                     raise SafetyError(
                         f"manifest {key} record disagrees with snapshot: {item['name']}"
                     )
+
+    protected_by_name = {
+        item["name"]: item for item in collections["protected"]
+    }
+    for item in collections["candidates"]:
+        reason = item["reason"]
+        if reason == "ephemeral_missing_root":
+            if (
+                not isinstance(item["ephemeral_prefix"], str)
+                or item["ephemeral_prefix"] not in prefixes
+            ):
+                raise SafetyError(
+                    f"manifest candidate has an unknown ephemeral prefix: "
+                    f"{item['name']}"
+                )
+            continue
+
+        string_fields = {"lexical_root", "resolved_root"}
+        if reason != "reserved_missing_root":
+            string_fields.update({"canonical_root", "common_dir"})
+        for field in string_fields:
+            value = item[field]
+            normalized = declared_root(value) if isinstance(value, str) else None
+            if normalized is None or str(normalized) != value:
+                raise SafetyError(
+                    f"manifest candidate {field} is invalid: {item['name']}"
+                )
+        registered_root = declared_root(item["root_path"])
+        if (
+            registered_root is None
+            or str(registered_root) != item["lexical_root"]
+        ):
+            raise SafetyError(
+                f"manifest candidate lexical root disagrees with registration: "
+                f"{item['name']}"
+            )
+        evidence = item["reserved_boundaries"]
+        if not isinstance(evidence, list):
+            raise SafetyError(
+                f"manifest candidate reserved boundaries are invalid: "
+                f"{item['name']}"
+            )
+        evidence_paths = [
+            ("lexical_root", pathlib.Path(item["lexical_root"])),
+            ("resolved_root", pathlib.Path(item["resolved_root"])),
+        ]
+        if reason != "reserved_missing_root":
+            expected_evidence = repository_reserved_evidence(
+                lexical_root=pathlib.Path(item["lexical_root"]),
+                resolved_root=pathlib.Path(item["resolved_root"]),
+                canonical_root=pathlib.Path(item["canonical_root"]),
+                common_dir=pathlib.Path(item["common_dir"]),
+                home=manifest_home,
+                platform=payload["platform"],
+            )
+        else:
+            expected_evidence = reserved_path_evidence(
+                evidence_paths,
+                home=manifest_home,
+                platform=payload["platform"],
+            )
+        if evidence != expected_evidence:
+            raise SafetyError(
+                f"manifest reserved boundary evidence is invalid: {item['name']}"
+            )
+        if reason in {"reserved_missing_root", "reserved_live_root"} and not evidence:
+            raise SafetyError(
+                f"manifest reserved candidate lacks boundary evidence: "
+                f"{item['name']}"
+            )
+        if reason == "reserved_live_root":
+            kinds = {entry["path_kind"] for entry in evidence}
+            if not {"canonical_root", "common_dir"} <= kinds:
+                raise SafetyError(
+                    f"manifest reserved live candidate lacks physical evidence: "
+                    f"{item['name']}"
+                )
+            continue
+        if reason == "reserved_missing_root":
+            continue
+
+        canonical_name = item["canonical_project"]
+        if (
+            not isinstance(canonical_name, str)
+            or not canonical_name
+            or not isinstance(item["canonical_project_root_path"], str)
+            or not isinstance(item["canonical_size_bytes"], int)
+            or item["canonical_size_bytes"] < 0
+        ):
+            raise SafetyError(
+                f"manifest canonical graph evidence is invalid: {item['name']}"
+            )
+        canonical = protected_by_name.get(canonical_name)
+        if canonical is None or canonical.get("reason") != "canonical_root":
+            raise SafetyError(
+                "manifest preservation target must be a final protected "
+                f"canonical graph: {item['name']}"
+            )
+        snapshot = snapshot_by_name[canonical_name]
+        if (
+            item["canonical_project_root_path"] != snapshot["root_path"]
+            or item["canonical_size_bytes"] != snapshot["size_bytes"]
+        ):
+            raise SafetyError(
+                f"manifest canonical graph evidence is invalid: {item['name']}"
+            )
+        canonical_registered = declared_root(snapshot["root_path"])
+        if canonical_registered is None:
+            raise SafetyError(
+                f"manifest canonical graph root is invalid: {item['name']}"
+            )
+        canonical_target_evidence = repository_reserved_evidence(
+            lexical_root=canonical_registered,
+            resolved_root=canonical_registered.resolve(strict=False),
+            canonical_root=pathlib.Path(item["canonical_root"]),
+            common_dir=pathlib.Path(item["common_dir"]),
+            home=manifest_home,
+            platform=payload["platform"],
+        )
+        if canonical_target_evidence:
+            raise SafetyError(
+                f"manifest reserved graph cannot preserve a candidate: "
+                f"{item['name']}"
+            )
 
     expected_blockers = [
         item
@@ -1043,7 +1641,18 @@ def revalidate_candidate(
     candidate: dict[str, Any],
     projects: list[dict[str, Any]],
     prefixes: list[pathlib.Path],
+    *,
+    protected_projects: dict[str, dict[str, Any]] | None = None,
+    home: pathlib.Path | None = None,
+    platform: str | None = None,
 ) -> None:
+    protected_projects = (
+        {} if protected_projects is None else protected_projects
+    )
+    home = lexical_absolute_path(
+        pathlib.Path.home() if home is None else home
+    )
+    platform = sys.platform if platform is None else platform
     current = next(
         (project for project in projects if project["name"] == candidate["name"]),
         None,
@@ -1054,37 +1663,105 @@ def revalidate_candidate(
         if current[field] != candidate[field]:
             raise SafetyError(f"candidate {field} changed: {candidate['name']}")
 
-    root = pathlib.Path(candidate["root_path"]).expanduser()
+    root = declared_root(candidate["root_path"])
+    if root is None:
+        raise SafetyError(f"candidate root is not absolute: {candidate['name']}")
     reason = candidate["reason"]
     if reason == "ephemeral_missing_root":
-        if root.exists():
+        dangling = dangling_symlink_component(root)
+        if root.exists() or dangling is not None:
             raise SafetyError(f"ephemeral root became live: {root}")
         expected_prefix = pathlib.Path(candidate["ephemeral_prefix"])
         if expected_prefix not in prefixes or not path_is_under(root, expected_prefix):
             raise SafetyError(f"ephemeral prefix guard failed: {root}")
         return
-    if reason not in {"canonical_alias_duplicate", "linked_worktree_duplicate"}:
+
+    if reason == "reserved_missing_root":
+        dangling = dangling_symlink_component(root)
+        if root.exists() or dangling is not None:
+            raise SafetyError(f"reserved missing root became live: {root}")
+        resolved_root = root.resolve(strict=False)
+        evidence = reserved_path_evidence(
+            [
+                ("lexical_root", root),
+                ("resolved_root", resolved_root),
+            ],
+            home=home,
+            platform=platform,
+        )
+        if (
+            str(root) != candidate["lexical_root"]
+            or str(resolved_root) != candidate["resolved_root"]
+            or evidence != candidate["reserved_boundaries"]
+        ):
+            raise SafetyError(
+                f"reserved missing root relationship changed: {root}"
+            )
+        return
+
+    if reason not in {
+        "reserved_live_root",
+        "canonical_alias_duplicate",
+        "linked_worktree_duplicate",
+    }:
         raise SafetyError(f"unsupported candidate reason: {reason}")
 
-    resolved = resolve_repository(root)
-    if resolved["root"] != str(root.resolve()):
+    details = resolve_repository_details(root)
+    resolved_root = root.resolve(strict=True)
+    evidence = repository_reserved_evidence(
+        lexical_root=root,
+        resolved_root=resolved_root,
+        canonical_root=details["canonical_root"],
+        common_dir=details["common_dir"],
+        home=home,
+        platform=platform,
+    )
+    if (
+        str(root) != candidate["lexical_root"]
+        or str(resolved_root) != candidate["resolved_root"]
+        or evidence != candidate["reserved_boundaries"]
+    ):
         raise SafetyError(f"candidate root changed: {root}")
-    if resolved["canonical_root"] != candidate["canonical_root"]:
+    if str(details["canonical_root"]) != candidate["canonical_root"]:
         raise SafetyError(f"candidate canonical root changed: {root}")
-    if resolved["common_dir"] != candidate["common_dir"]:
+    if str(details["common_dir"]) != candidate["common_dir"]:
         raise SafetyError(f"candidate Git common dir changed: {root}")
+    if reason == "reserved_live_root":
+        if not (
+            reserved_index_path(
+                details["canonical_root"],
+                home=home,
+                platform=platform,
+            )
+            and reserved_index_path(
+                details["common_dir"],
+                home=home,
+                platform=platform,
+            )
+        ):
+            raise SafetyError(
+                f"reserved live root left its reserved boundary: {root}"
+            )
+        return
+
     if reason == "linked_worktree_duplicate":
-        if not resolved["linked_worktree"]:
+        if not details["linked_worktree"]:
             raise SafetyError(f"candidate is no longer a linked worktree: {root}")
     else:
-        if resolved["linked_worktree"]:
+        if details["linked_worktree"]:
             raise SafetyError(f"canonical alias became a linked worktree: {root}")
         if declared_root(candidate["root_path"]) == pathlib.Path(
             candidate["canonical_root"]
         ):
             raise SafetyError(f"canonical alias became the canonical path: {root}")
-    if not resolved["clone"]["full"]:
+    if not details["clone"]["full"]:
         raise SafetyError(f"candidate canonical clone is not full: {root}")
+    protected = protected_projects.get(candidate["canonical_project"])
+    if protected is None or protected.get("reason") != "canonical_root":
+        raise SafetyError(
+            "candidate canonical graph is not final protected: "
+            f"{candidate['canonical_project']}"
+        )
     canonical = next(
         (
             project
@@ -1097,13 +1774,40 @@ def revalidate_candidate(
         raise SafetyError(f"canonical graph disappeared: {candidate['canonical_project']}")
     if canonical["root_path"] != candidate["canonical_project_root_path"]:
         raise SafetyError(f"canonical graph registration changed: {candidate['canonical_project']}")
-    if (
-        pathlib.Path(canonical["root_path"]).expanduser().resolve()
-        != pathlib.Path(candidate["canonical_root"])
+    canonical_root = declared_root(canonical["root_path"])
+    if canonical_root is None:
+        raise SafetyError(
+            f"canonical graph root is not absolute: {candidate['canonical_project']}"
+        )
+    canonical_details = resolve_repository_details(canonical_root)
+    if canonical_root.resolve(strict=True) != pathlib.Path(
+        candidate["canonical_root"]
     ):
         raise SafetyError(f"canonical graph root changed: {candidate['canonical_project']}")
     if canonical["size_bytes"] != candidate["canonical_size_bytes"]:
         raise SafetyError(f"canonical graph size changed: {candidate['canonical_project']}")
+    if (
+        str(canonical_details["canonical_root"]) != candidate["canonical_root"]
+        or str(canonical_details["common_dir"]) != candidate["common_dir"]
+    ):
+        raise SafetyError(
+            f"canonical graph relationship changed: "
+            f"{candidate['canonical_project']}"
+        )
+    if not canonical_details["clone"]["full"]:
+        raise SafetyError(f"candidate canonical clone is not full: {root}")
+    canonical_evidence = repository_reserved_evidence(
+        lexical_root=canonical_root,
+        resolved_root=canonical_root.resolve(strict=True),
+        canonical_root=canonical_details["canonical_root"],
+        common_dir=canonical_details["common_dir"],
+        home=home,
+        platform=platform,
+    )
+    if canonical_evidence:
+        raise SafetyError(
+            f"reserved canonical graph cannot preserve candidate: {root}"
+        )
 
 
 def delete_project_command(binary: str, project_name: str) -> list[str]:
@@ -1288,16 +1992,35 @@ def execute_delete_batch(
     fingerprints: dict[str, dict[str, dict[str, int] | None]],
     expected_snapshot: list[dict[str, Any]],
     prefixes: list[pathlib.Path],
+    relationship_candidates: list[dict[str, Any]] | None = None,
+    protected_projects: dict[str, dict[str, Any]] | None = None,
+    home: pathlib.Path | None = None,
+    platform: str | None = None,
 ) -> tuple[
     list[dict[str, Any]],
     list[dict[str, Any]],
     dict[str, Any],
 ]:
+    relationship_candidates = (
+        candidates
+        if relationship_candidates is None
+        else relationship_candidates
+    )
+    protected_projects = (
+        {} if protected_projects is None else protected_projects
+    )
     deadline = time.monotonic() + DELETE_BATCH_TIMEOUT_SECONDS
     projects = list_projects(binary)
     validate_snapshot(expected_snapshot, projects)
     for candidate in candidates:
-        revalidate_candidate(candidate, projects, prefixes)
+        revalidate_candidate(
+            candidate,
+            projects,
+            prefixes,
+            protected_projects=protected_projects,
+            home=home,
+            platform=platform,
+        )
     live_fingerprints = {
         candidate["name"]: cache_fingerprint(
             db_path(cache_dir, candidate["name"])
@@ -1348,6 +2071,21 @@ def execute_delete_batch(
                 f"project cache fingerprint changed during final holder sweep: "
                 f"{candidate['name']}"
             )
+
+    projects = list_projects(binary)
+    validate_snapshot(expected_snapshot, projects)
+    registered = {project["name"] for project in projects}
+    for candidate in relationship_candidates:
+        if candidate["name"] not in registered:
+            continue
+        revalidate_candidate(
+            candidate,
+            projects,
+            prefixes,
+            protected_projects=protected_projects,
+            home=home,
+            platform=platform,
+        )
 
     children: list[dict[str, Any]] = []
     launched: set[str] = set()
@@ -1519,15 +2257,28 @@ def preflight_candidates(
     expected_snapshot: list[dict[str, Any]],
     prefixes: list[pathlib.Path],
     lsof_timeout_seconds: int,
+    protected_projects: dict[str, dict[str, Any]] | None = None,
+    home: pathlib.Path | None = None,
+    platform: str | None = None,
 ) -> tuple[
     dict[str, dict[str, dict[str, int] | None]],
     str | None,
 ]:
     fingerprints: dict[str, dict[str, dict[str, int] | None]] = {}
+    protected_projects = (
+        {} if protected_projects is None else protected_projects
+    )
     for candidate in candidates:
         projects = list_projects(binary)
         validate_snapshot(expected_snapshot, projects)
-        revalidate_candidate(candidate, projects, prefixes)
+        revalidate_candidate(
+            candidate,
+            projects,
+            prefixes,
+            protected_projects=protected_projects,
+            home=home,
+            platform=platform,
+        )
         path = db_path(cache_dir, candidate["name"])
         fingerprints[candidate["name"]] = capture_cache_baseline(
             path, candidate["size_bytes"]
@@ -1638,7 +2389,7 @@ def candidate_execution_summary(
 def audit(args: argparse.Namespace) -> int:
     binary = cbm_binary(args.cbm_bin)
     cache_dir = cbm_cache_dir(args.cache_dir)
-    home = pathlib.Path.home().resolve()
+    home = lexical_absolute_path(pathlib.Path.home())
     prefixes = sorted(
         {
             normalize_prefix(value, cache_dir=cache_dir, home=home)
@@ -1650,6 +2401,8 @@ def audit(args: argparse.Namespace) -> int:
         projects=projects,
         cache_dir=cache_dir,
         ephemeral_prefixes=prefixes,
+        home=home,
+        platform=sys.platform,
     )
     manifest_path = pathlib.Path(args.manifest).expanduser().resolve()
     write_manifest(manifest_path, payload)
@@ -1666,6 +2419,9 @@ def audit(args: argparse.Namespace) -> int:
                 "candidate_bytes": sum(
                     item["size_bytes"] for item in payload["candidates"]
                 ),
+                "operational_preconditions": payload[
+                    "operational_preconditions"
+                ],
                 "applied": False,
             },
             sort_keys=True,
@@ -1692,7 +2448,15 @@ def prune(args: argparse.Namespace) -> int:
         raise SafetyError(
             f"cache root mismatch: {cache_dir} != {payload.get('cache_dir')}"
         )
-    home = pathlib.Path.home().resolve()
+    home = lexical_absolute_path(pathlib.Path.home())
+    if payload["home"] != str(home):
+        raise SafetyError(
+            f"manifest home mismatch: {payload['home']} != {home}"
+        )
+    if payload["platform"] != sys.platform:
+        raise SafetyError(
+            f"manifest platform mismatch: {payload['platform']} != {sys.platform}"
+        )
     prefixes = []
     for value in payload["ephemeral_prefixes"]:
         normalized = normalize_prefix(value, cache_dir=cache_dir, home=home)
@@ -1710,8 +2474,18 @@ def prune(args: argparse.Namespace) -> int:
         )
 
     expected_snapshot = list(payload["snapshot"])
+    protected_projects = {
+        item["name"]: item for item in payload["protected"]
+    }
     for candidate in runtime_protected:
-        revalidate_candidate(candidate, projects, prefixes)
+        revalidate_candidate(
+            candidate,
+            projects,
+            prefixes,
+            protected_projects=protected_projects,
+            home=home,
+            platform=sys.platform,
+        )
     fingerprints, lsof = preflight_candidates(
         binary=binary,
         cache_dir=cache_dir,
@@ -1719,6 +2493,9 @@ def prune(args: argparse.Namespace) -> int:
         expected_snapshot=expected_snapshot,
         prefixes=prefixes,
         lsof_timeout_seconds=args.lsof_timeout_seconds,
+        protected_projects=protected_projects,
+        home=home,
+        platform=sys.platform,
     )
     execution_summary = candidate_execution_summary(
         manifest_candidates=payload["candidates"],
@@ -1740,6 +2517,9 @@ def prune(args: argparse.Namespace) -> int:
                     ),
                     "blocked_manifest_allowed": args.allow_blocked_manifest,
                     "lsof_timeout_seconds": args.lsof_timeout_seconds,
+                    "operational_preconditions": payload[
+                        "operational_preconditions"
+                    ],
                     "applied": False,
                 },
                 sort_keys=True,
@@ -1770,6 +2550,10 @@ def prune(args: argparse.Namespace) -> int:
                     fingerprints=fingerprints,
                     expected_snapshot=expected_snapshot,
                     prefixes=prefixes,
+                    relationship_candidates=payload["candidates"],
+                    protected_projects=protected_projects,
+                    home=home,
+                    platform=sys.platform,
                 )
             except DeleteBatchError as error:
                 outcomes = merge_outcome_reports(outcomes, error.report)
@@ -1808,6 +2592,9 @@ def prune(args: argparse.Namespace) -> int:
                 "skipped": [],
                 "blocked_manifest_allowed": args.allow_blocked_manifest,
                 "lsof_timeout_seconds": args.lsof_timeout_seconds,
+                "operational_preconditions": payload[
+                    "operational_preconditions"
+                ],
                 "before_projects": before_projects,
                 "before_bytes": before_bytes,
                 "after_projects": len(projects),

--- a/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
+++ b/skills/codebase-memory-mcp/scripts/codebase_memory_cache.py
@@ -2087,6 +2087,13 @@ def execute_delete_batch(
             platform=platform,
         )
 
+    require_fingerprints(
+        cache_dir=cache_dir,
+        candidates=candidates,
+        fingerprints=post_lsof_fingerprints,
+        phase="during final relationship revalidation",
+    )
+
     children: list[dict[str, Any]] = []
     launched: set[str] = set()
     failed: set[str] = set()

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -399,6 +399,461 @@ class ResolverTests(unittest.TestCase):
         self.assertIn("missing or not a directory", result.stderr)
 
 
+class ReservedCacheClassificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.temp = pathlib.Path(self.temporary.name)
+        self.home = self.temp / "home"
+        self.cache = self.temp / "cache"
+        self.home.mkdir()
+        self.cache.mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def project(
+        self,
+        name: str,
+        root: pathlib.Path,
+        *,
+        size_bytes: int = 1,
+    ) -> dict[str, object]:
+        return {
+            "name": name,
+            "root_path": str(root),
+            "size_bytes": size_bytes,
+            "nodes": 1,
+            "edges": 1,
+        }
+
+    def manifest(
+        self,
+        projects: list[dict[str, object]],
+        *,
+        platform: str = "darwin",
+    ) -> dict[str, object]:
+        payload = CBM.build_manifest(
+            projects=projects,
+            cache_dir=self.cache,
+            ephemeral_prefixes=[],
+            home=self.home,
+            platform=platform,
+        )
+        CBM.validate_manifest_relationships(payload)
+        return payload
+
+    def record(
+        self,
+        payload: dict[str, object],
+        name: str,
+    ) -> dict[str, object]:
+        for collection in ("candidates", "protected"):
+            for item in payload[collection]:
+                if item["name"] == name:
+                    return item
+        raise AssertionError(name)
+
+    def test_reserved_boundaries_and_exact_component_negatives(self) -> None:
+        reserved = {
+            "codex": self.home / ".codex" / "worktrees" / "gone",
+            "gwt": self.home / "GIT" / "_Worktrees" / "gone",
+            "component": self.temp / "repo" / ".worktrees" / "gone",
+            "mixed": self.temp / "repo" / ".WorkTrees" / "gone",
+        }
+        lookalikes = {
+            "codex-lookalike": self.home / ".codex" / "worktrees-copy" / "gone",
+            "gwt-lookalike": self.home / "GIT" / "_WorktreesExtra" / "gone",
+            "component-prefix": self.temp / "repo" / ".worktrees-copy" / "gone",
+            "component-suffix": self.temp / "repo" / "x.worktrees" / "gone",
+        }
+        payload = self.manifest(
+            [
+                self.project(name, path)
+                for name, path in {**reserved, **lookalikes}.items()
+            ]
+        )
+        for name in reserved:
+            self.assertEqual(
+                self.record(payload, name)["reason"],
+                "reserved_missing_root",
+            )
+        for name in lookalikes:
+            self.assertEqual(
+                self.record(payload, name)["reason"],
+                "missing_root_outside_prefix",
+            )
+        self.assertEqual(payload["operational_preconditions"], [])
+
+        linux = self.manifest(
+            [self.project("mixed", reserved["mixed"])],
+            platform="linux",
+        )
+        self.assertEqual(
+            self.record(linux, "mixed")["reason"],
+            "missing_root_outside_prefix",
+        )
+        tmp_evidence = CBM.reserved_path_evidence(
+            [
+                ("lexical_root", pathlib.Path("/tmp/example/repo")),
+                ("resolved_root", pathlib.Path("/private/tmp/example/repo")),
+            ],
+            home=self.home,
+            platform="darwin",
+        )
+        self.assertEqual(
+            {
+                (item["path_kind"], item["boundary"])
+                for item in tmp_evidence
+            },
+            {
+                ("lexical_root", "/tmp"),
+                ("resolved_root", "/private/tmp"),
+            },
+        )
+
+    def test_reserved_alias_and_linked_worktree_use_protected_owner(self) -> None:
+        owner = self.temp / "owner"
+        init_repo(owner)
+        alias = self.home / "GIT" / "_Worktrees" / "alias"
+        linked = self.home / ".codex" / "worktrees" / "linked"
+        alias.parent.mkdir(parents=True)
+        linked.parent.mkdir(parents=True)
+        alias.symlink_to(owner, target_is_directory=True)
+        command(
+            "git",
+            "-C",
+            str(owner),
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "reserved-linked",
+            str(linked),
+        )
+        payload = self.manifest(
+            [
+                self.project("owner", owner),
+                self.project("alias", alias),
+                self.project("linked", linked),
+            ]
+        )
+        self.assertEqual(self.record(payload, "owner")["reason"], "canonical_root")
+        self.assertEqual(
+            self.record(payload, "alias")["reason"],
+            "canonical_alias_duplicate",
+        )
+        self.assertEqual(
+            self.record(payload, "linked")["reason"],
+            "linked_worktree_duplicate",
+        )
+        for name in ("alias", "linked"):
+            self.assertEqual(
+                self.record(payload, name)["canonical_project"],
+                "owner",
+            )
+
+    def test_alias_into_reserved_owner_and_shared_owner_are_independent(self) -> None:
+        owner = self.home / ".codex" / "worktrees" / "owner"
+        owner.parent.mkdir(parents=True)
+        init_repo(owner)
+        alias = self.temp / "safe-alias"
+        alias.symlink_to(owner, target_is_directory=True)
+        payload = self.manifest(
+            [
+                self.project("reserved-owner", owner),
+                self.project("safe-alias", alias),
+            ]
+        )
+        self.assertEqual(
+            {
+                item["name"]: item["reason"]
+                for item in payload["candidates"]
+            },
+            {
+                "reserved-owner": "reserved_live_root",
+                "safe-alias": "reserved_live_root",
+            },
+        )
+        self.assertFalse(payload["protected"])
+        self.assertEqual(
+            payload["operational_preconditions"],
+            [CBM.RESERVED_ROOT_OPERATIONAL_PRECONDITION],
+        )
+
+    def test_reserved_live_full_shallow_promisor_and_partial_are_candidates(
+        self,
+    ) -> None:
+        origin = self.temp / "origin"
+        init_repo(origin)
+        base = self.home / ".codex" / "worktrees"
+        base.mkdir(parents=True)
+        full = base / "full"
+        shallow = base / "shallow"
+        promisor = base / "promisor"
+        partial = base / "partial"
+        init_repo(full)
+        command(
+            "git",
+            "clone",
+            "-q",
+            "--depth",
+            "1",
+            f"file://{origin}",
+            str(shallow),
+        )
+        init_repo(promisor)
+        command(
+            "git",
+            "-C",
+            str(promisor),
+            "config",
+            "remote.origin.promisor",
+            "true",
+        )
+        init_repo(partial)
+        command(
+            "git",
+            "-C",
+            str(partial),
+            "config",
+            "remote.origin.partialclonefilter",
+            "blob:none",
+        )
+        payload = self.manifest(
+            [
+                self.project(name, path)
+                for name, path in (
+                    ("full", full),
+                    ("shallow", shallow),
+                    ("promisor", promisor),
+                    ("partial", partial),
+                )
+            ]
+        )
+        self.assertEqual(
+            {item["reason"] for item in payload["candidates"]},
+            {"reserved_live_root"},
+        )
+        self.assertEqual(len(payload["candidates"]), 4)
+
+    def test_reserved_bare_non_git_and_dangling_roots_block(self) -> None:
+        base = self.home / ".codex" / "worktrees"
+        base.mkdir(parents=True)
+        bare = base / "bare.git"
+        invalid = base / "invalid"
+        dangling = base / "dangling"
+        command("git", "init", "-q", "--bare", str(bare))
+        invalid.mkdir()
+        dangling.symlink_to(base / "missing-target", target_is_directory=True)
+        payload = self.manifest(
+            [
+                self.project("bare", bare),
+                self.project("invalid", invalid),
+                self.project("dangling", dangling),
+            ]
+        )
+        self.assertEqual(
+            {item["reason"] for item in payload["protected"]},
+            {"live_root_unmapped"},
+        )
+        self.assertEqual(
+            {item["name"] for item in payload["blockers"]},
+            {"bare", "invalid", "dangling"},
+        )
+
+    def test_external_unhealthy_owner_and_missing_graph_block_alias(self) -> None:
+        origin = self.temp / "origin"
+        init_repo(origin)
+        shallow = self.temp / "shallow"
+        promisor = self.temp / "promisor"
+        partial = self.temp / "partial"
+        command(
+            "git",
+            "clone",
+            "-q",
+            "--depth",
+            "1",
+            f"file://{origin}",
+            str(shallow),
+        )
+        init_repo(promisor)
+        command(
+            "git",
+            "-C",
+            str(promisor),
+            "config",
+            "remote.origin.promisor",
+            "true",
+        )
+        init_repo(partial)
+        command(
+            "git",
+            "-C",
+            str(partial),
+            "config",
+            "remote.origin.partialclonefilter",
+            "blob:none",
+        )
+        aliases = []
+        for name, owner in (
+            ("shallow", shallow),
+            ("promisor", promisor),
+            ("partial", partial),
+        ):
+            alias = self.home / "GIT" / "_Worktrees" / name
+            alias.parent.mkdir(parents=True, exist_ok=True)
+            alias.symlink_to(owner, target_is_directory=True)
+            aliases.append(alias)
+            unhealthy = self.manifest(
+                [
+                    self.project(f"{name}-owner", owner),
+                    self.project(f"{name}-alias", alias),
+                ]
+            )
+            self.assertEqual(
+                self.record(unhealthy, f"{name}-alias")["reason"],
+                "canonical_clone_not_full",
+            )
+
+        missing = self.manifest([self.project("alias", aliases[0])])
+        self.assertEqual(
+            self.record(missing, "alias")["reason"],
+            "missing_canonical_graph",
+        )
+
+    def test_nonreserved_sole_alias_stays_protected(self) -> None:
+        owner = self.temp / "owner"
+        alias = self.temp / "alias"
+        init_repo(owner)
+        alias.symlink_to(owner, target_is_directory=True)
+        payload = self.manifest([self.project("alias", alias)])
+        self.assertFalse(payload["candidates"])
+        self.assertEqual(
+            self.record(payload, "alias")["reason"],
+            "canonical_root",
+        )
+
+    def test_reserved_missing_reappearance_and_ancestor_retarget_abort(self) -> None:
+        direct = self.home / ".codex" / "worktrees" / "direct"
+        direct.parent.mkdir(parents=True)
+        direct_projects = [self.project("direct", direct)]
+        direct_payload = self.manifest(direct_projects)
+        direct_candidate = self.record(direct_payload, "direct")
+        direct.mkdir()
+        with self.assertRaisesRegex(
+            CBM.SafetyError,
+            "reserved missing root became live",
+        ):
+            CBM.revalidate_candidate(
+                direct_candidate,
+                direct_projects,
+                [],
+                home=self.home,
+                platform="darwin",
+            )
+
+        target_a = self.temp / "target-a"
+        target_b = self.temp / "target-b"
+        target_a.mkdir()
+        target_b.mkdir()
+        ancestor = self.home / "GIT" / "_Worktrees" / "ancestor"
+        ancestor.parent.mkdir(parents=True)
+        ancestor.symlink_to(target_a, target_is_directory=True)
+        missing = ancestor / "gone"
+        projects = [self.project("retarget", missing)]
+        payload = self.manifest(projects)
+        candidate = self.record(payload, "retarget")
+        ancestor.unlink()
+        ancestor.symlink_to(target_b, target_is_directory=True)
+        with self.assertRaisesRegex(
+            CBM.SafetyError,
+            "relationship changed",
+        ):
+            CBM.revalidate_candidate(
+                candidate,
+                projects,
+                [],
+                home=self.home,
+                platform="darwin",
+            )
+
+    def test_reserved_live_canonical_and_common_dir_drift_abort(self) -> None:
+        first = self.home / ".codex" / "worktrees" / "first"
+        second = self.home / ".codex" / "worktrees" / "second"
+        first.parent.mkdir(parents=True)
+        init_repo(first)
+        init_repo(second)
+        alias = self.temp / "alias"
+        alias.symlink_to(first, target_is_directory=True)
+        projects = [self.project("alias", alias)]
+        payload = self.manifest(projects)
+        candidate = self.record(payload, "alias")
+        alias.unlink()
+        alias.symlink_to(second, target_is_directory=True)
+        with self.assertRaises(CBM.SafetyError):
+            CBM.revalidate_candidate(
+                candidate,
+                projects,
+                [],
+                home=self.home,
+                platform="darwin",
+            )
+
+    def test_manifest_rejects_candidate_preservation_and_reason_tamper(
+        self,
+    ) -> None:
+        owner = self.temp / "owner"
+        init_repo(owner)
+        alias = self.home / "GIT" / "_Worktrees" / "alias"
+        alias.parent.mkdir(parents=True)
+        alias.symlink_to(owner, target_is_directory=True)
+        missing = self.home / ".codex" / "worktrees" / "missing"
+        payload = self.manifest(
+            [
+                self.project("owner", owner),
+                self.project("alias", alias),
+                self.project("missing", missing),
+            ]
+        )
+        alias_candidate = next(
+            item for item in payload["candidates"] if item["name"] == "alias"
+        )
+        missing_candidate = next(
+            item for item in payload["candidates"] if item["name"] == "missing"
+        )
+        alias_candidate["canonical_project"] = "missing"
+        alias_candidate["canonical_project_root_path"] = missing_candidate[
+            "root_path"
+        ]
+        alias_candidate["canonical_size_bytes"] = missing_candidate["size_bytes"]
+        with self.assertRaisesRegex(
+            CBM.SafetyError,
+            "final protected canonical graph",
+        ):
+            CBM.validate_manifest_relationships(payload)
+
+        clean = self.manifest([self.project("missing", missing)])
+        clean["candidates"][0]["detail"] = "tampered"
+        with self.assertRaisesRegex(
+            CBM.SafetyError,
+            "fields are invalid",
+        ):
+            CBM.validate_manifest_relationships(clean)
+
+    def test_stale_schema_is_rejected(self) -> None:
+        missing = self.home / ".codex" / "worktrees" / "missing"
+        payload = self.manifest([self.project("missing", missing)])
+        payload["schema_version"] = 1
+        payload["manifest_digest"] = CBM.manifest_digest(payload)
+        path = self.temp / "stale-manifest.json"
+        path.write_text(json.dumps(payload))
+        with self.assertRaisesRegex(
+            CBM.SafetyError,
+            "unsupported manifest schema",
+        ):
+            CBM.load_manifest(path)
+
+
 class DatabaseValidationTests(unittest.TestCase):
     def test_uses_exact_immutable_read_only_uri(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -1090,7 +1545,7 @@ class DeletionBatchTests(unittest.TestCase):
                 mock.patch.object(
                     CBM,
                     "list_projects",
-                    side_effect=[[], [second_registered]],
+                    side_effect=[[], [], [second_registered]],
                 ) as list_projects,
                 mock.patch.object(CBM, "validate_snapshot"),
                 mock.patch.object(CBM, "revalidate_candidate"),
@@ -1118,7 +1573,7 @@ class DeletionBatchTests(unittest.TestCase):
 
             report = raised.exception.report
             self.assertTrue(process.communicated)
-            self.assertEqual(list_projects.call_count, 2)
+            self.assertEqual(list_projects.call_count, 3)
             self.assertEqual(
                 [
                     json.loads(call.args[0][3])["project"]
@@ -1189,7 +1644,7 @@ class DeletionBatchTests(unittest.TestCase):
                 mock.patch.object(
                     CBM,
                     "list_projects",
-                    side_effect=[[], [registered]],
+                    side_effect=[[], [], [registered]],
                 ),
                 mock.patch.object(CBM, "validate_snapshot"),
                 mock.patch.object(CBM, "revalidate_candidate"),
@@ -1383,6 +1838,8 @@ if os.environ.get("FAKE_LSOF_MUTATE_ON_CALL") == str(call + 1):
     action = os.environ.get("FAKE_LSOF_MUTATE_ACTION", "append")
     if action == "create":
         target.write_bytes(b"")
+    elif action == "mkdir":
+        target.mkdir(parents=True)
     elif action == "remove":
         target.unlink()
     elif action == "touch":
@@ -1615,7 +2072,10 @@ raise SystemExit(module.main())
         self.assertFalse((self.cache / f"{self.worktree_name}.db").exists())
         events = self.events.read_text().splitlines()
         delete_index = events.index(f"delete-start:{self.worktree_name}")
-        self.assertEqual(events[delete_index - 1], "lsof")
+        self.assertEqual(events[delete_index - 2 : delete_index], [
+            "lsof",
+            "list_projects",
+        ])
 
     def test_successful_holder_call_counts_match_batch_contract(self) -> None:
         self.audit()
@@ -1752,7 +2212,10 @@ raise SystemExit(module.main())
             "list_projects",
             events[prior_end + 1 : next_start],
         )
-        self.assertEqual(events[next_start - 1], "lsof")
+        self.assertEqual(events[next_start - 2 : next_start], [
+            "lsof",
+            "list_projects",
+        ])
 
     def test_sidecar_holder_blocks_final_batch_before_any_launch(self) -> None:
         name = "fixture-z-ephemeral"
@@ -1804,6 +2267,55 @@ raise SystemExit(module.main())
                 for event in self.events.read_text().splitlines()
             )
         )
+
+    def test_future_reserved_relationship_drift_after_final_lsof_blocks_batch(
+        self,
+    ) -> None:
+        for index in range(8):
+            self.add_ephemeral_candidate(f"fixture-a-{index}")
+        with tempfile.TemporaryDirectory(
+            prefix="cbm-reserved-",
+            dir="/tmp",
+        ) as reserved_directory:
+            missing = pathlib.Path(reserved_directory) / "gone"
+            name = "fixture-z-reserved"
+            self.projects.append(
+                {
+                    "name": name,
+                    "root_path": str(missing),
+                    "size_bytes": sqlite_file(self.cache / f"{name}.db"),
+                    "nodes": 1,
+                    "edges": 1,
+                }
+            )
+            self.write_projects(self.projects)
+            self.audit("--ephemeral-prefix", str(self.temp / "ephemeral"))
+            manifest = json.loads(self.manifest.read_text())
+            self.assertEqual(
+                next(
+                    item
+                    for item in manifest["candidates"]
+                    if item["name"] == name
+                )["reason"],
+                "reserved_missing_root",
+            )
+            environment = {
+                **self.environment,
+                "FAKE_LSOF_MUTATE_ON_CALL": "3",
+                "FAKE_LSOF_MUTATE_PATH": str(missing),
+                "FAKE_LSOF_MUTATE_ACTION": "mkdir",
+            }
+
+            result = self.apply(check=False, env=environment)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("reserved missing root became live", result.stderr)
+            self.assertFalse(self.deleted.exists())
+            self.assertFalse(
+                any(
+                    event.startswith("delete-start:")
+                    for event in self.events.read_text().splitlines()
+                )
+            )
 
     def test_nonzero_in_first_batch_drains_and_stops_future_batches(self) -> None:
         for index in range(8):

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -2953,6 +2953,28 @@ raise SystemExit(module.main())
         self.assertIn("fingerprint changed", result.stderr)
         self.assertFalse(self.deleted.exists())
 
+    def test_fingerprint_change_during_final_relationship_scan_stops_batch(
+        self,
+    ) -> None:
+        self.audit()
+        list_calls = pathlib.Path(self.environment["FAKE_CBM_LIST_CALLS"])
+        list_calls.write_text("0")
+        environment = {
+            **self.environment,
+            "FAKE_CBM_MUTATE_ON_LIST_CALL": "4",
+            "FAKE_CBM_MUTATE_PATH": str(
+                self.cache / f"{self.worktree_name}.db"
+            ),
+        }
+        result = self.apply(check=False, env=environment)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "fingerprint changed during final relationship revalidation",
+            result.stderr,
+        )
+        self.assertIn("already_deleted=[]", result.stderr)
+        self.assertFalse(self.deleted.exists())
+
     def test_sidecar_change_after_preflight_stops_before_delete(self) -> None:
         database = self.cache / f"{self.worktree_name}.db"
         sidecar = pathlib.Path(f"{database}-shm")

--- a/tests/codebase_memory_cache_test.py
+++ b/tests/codebase_memory_cache_test.py
@@ -401,7 +401,7 @@ class ResolverTests(unittest.TestCase):
 
 class ReservedCacheClassificationTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.temporary = tempfile.TemporaryDirectory()
+        self.temporary = tempfile.TemporaryDirectory(dir=pathlib.Path.home())
         self.temp = pathlib.Path(self.temporary.name)
         self.home = self.temp / "home"
         self.cache = self.temp / "cache"
@@ -1683,7 +1683,7 @@ class DeletionBatchTests(unittest.TestCase):
 
 class CacheManifestTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.temporary = tempfile.TemporaryDirectory()
+        self.temporary = tempfile.TemporaryDirectory(dir=pathlib.Path.home())
         self.temp = pathlib.Path(self.temporary.name)
         self.main = self.temp / "main"
         self.worktree = self.temp / "worktree"


### PR DESCRIPTION
## What changed

- classify missing and live graphs under built-in reserved roots as guarded cleanup candidates
- require duplicate candidates to preserve only a registered, healthy, final-protected nonreserved canonical graph
- freeze and revalidate lexical, resolved, canonical-root, common-dir, and reserved-boundary evidence
- bump the manifest schema and reject stale or reason-inconsistent manifests
- revalidate every remaining candidate relationship after the final holder sweep and before deletion starts
- document and report the external prevention/quiescence precondition for live reserved graph deletion

## Validation

- `TMPDIR=/tmp /usr/bin/python3 -m unittest -v tests/codebase_memory_cache_test.py tests/codebase_memory_gateway_test.py` (Python 3.9.6, 100 passed)
- `make test` (78 Node tests, 4 goal-report tests, 15 org-cleanup tests, 102 discovered Python tests)
- `make validate`
- `make validate-spec`
- `make check-generated`
- `pre-commit run --all-files`
- `shellcheck skills/codebase-memory-mcp/scripts/codebase-memory-graph.sh scripts/*.sh`
- `git diff --check`

## Scope

Code, tests, and documentation only. No cache deletion, process control, fleet probing, deployment, or merge.
