### PR TITLE
fix(workflows): bound agent monitoring and artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ validate-spec:
 test:
 	node --test skills/openclaw-pr-batch-sweep/scripts/*.test.mjs
 	python3 skills/codex-goal-mining/scripts/codex-goal-report-test.py
+	python3 skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot_test.py
 	python3 skills/org-branch-cleanup/scripts/test_org_branch_cleanup.py
 	python3 -m unittest discover -s tests -p '*_test.py'
 

--- a/skills/codex-goal-mining/SKILL.md
+++ b/skills/codex-goal-mining/SKILL.md
@@ -23,13 +23,25 @@ Recover structured Codex goal history and convert free-form runs into evidence-b
    - Fleet report: `scripts/codex-goal-report.py --policy ~/.config/codex-goal-mining/fleet-policy.json --json --output ~/.codex/reports/codex-fleet-goals.json`
    - Local only: `scripts/codex-goal-report.py --local --json`
    - Recent window: add `--since YYYY-MM-DD`.
+   - Exact activity window: add `--activity-overlap --since <ISO> --until <ISO>`.
+     Existing `--since` semantics remain creation-time based without that flag.
+   - Bounded repeat snapshots: add `--cursor-file <path>` to compute reset-safe
+     deltas. No cursor or report directory is created by default.
    - Selected machines: repeat `--machine <fleet-alias>`.
+   - Require fleet coverage with `--fleet`; any unreachable source is rendered
+     and returns nonzero instead of silently reporting success.
+   - Use `--one-attempt` for a single configured/first interpreter attempt per
+     host. Policy entries may declare `python` and `wsl_python`.
    - Start fleet configuration from `references/fleet-policy.example.json`; never commit a real private inventory.
 2. Treat the data sources correctly.
    - Prefer `goals_1.sqlite` for objective, status, tokens, and Codex-recorded active goal time.
    - Join `state_5.sqlite` for thread timestamps and rollout paths.
    - Use JSONL only as a fallback for older installations.
    - Wall-clock thread span includes idle and resume gaps; never describe it as active labor.
+   - Goal database counters are lifetime snapshots. Only cursor deltas have an
+     observation interval, and a reset is unknown rather than zero.
+   - Preserve root/child identity where the state database supplies it. JSONL
+     fallback reports unknown rather than guessing.
 3. Report collection coverage first.
    - List reached and unreachable machines.
    - Give the date range, goal count, statuses, total active goal time, and median goal time.
@@ -44,9 +56,13 @@ Recover structured Codex goal history and convert free-form runs into evidence-b
    - Include a fixed matrix, evidence requirements, blocker rules, and definition of done.
    - Start from `references/goal-suite-patterns.md`, then adapt to current evidence.
 6. Keep reports private.
-   - Default to `~/.codex/reports/` or another private path.
+   - Default to terminal/JSON delivery. Use `--output` only when retained output
+     was requested or required.
    - Scrub secrets, private hosts, personal absolute paths, and credentials before creating a gist or sharing externally.
    - Use a secret gist unless the user explicitly requests public visibility.
+7. For retained output or resumable collection state, apply the task artifact
+   contract from `$operations-worktree`. Reuse identity-matched canonical
+   inventories instead of copying large payloads.
 
 ## Inputs
 - Local Codex stores under `~/.codex/`.

--- a/skills/codex-goal-mining/references/fleet-policy.example.json
+++ b/skills/codex-goal-mining/references/fleet-policy.example.json
@@ -4,11 +4,14 @@
       "ssh_target": null
     },
     "desktop": {
-      "ssh_target": "desktop-ssh-alias"
+      "ssh_target": "desktop-ssh-alias",
+      "python": "python3"
     },
     "windows": {
       "ssh_target": "windows-ssh-alias",
-      "wsl_target": "windows-wsl-ssh-alias"
+      "python": "py -3",
+      "wsl_target": "windows-wsl-ssh-alias",
+      "wsl_python": "python3"
     }
   }
 }

--- a/skills/codex-goal-mining/scripts/codex-goal-report-test.py
+++ b/skills/codex-goal-mining/scripts/codex-goal-report-test.py
@@ -2,8 +2,11 @@
 import importlib.util
 import json
 import pathlib
+import sqlite3
+import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "codex-goal-report.py"
@@ -20,20 +23,29 @@ def write_session(path, events):
             handle.write(json.dumps(event, separators=(",", ":")) + "\n")
 
 
-def goal_event(timestamp, objective, status, seconds, tokens, updated_at):
+def goal_event(
+    timestamp,
+    objective,
+    status,
+    seconds,
+    tokens,
+    updated_at,
+    created_at=1780272000,
+    thread_id="thread-1",
+):
     return {
         "timestamp": timestamp,
         "type": "event_msg",
         "payload": {
             "type": "thread_goal_updated",
-            "threadId": "thread-1",
+            "threadId": thread_id,
             "goal": {
-                "threadId": "thread-1",
+                "threadId": thread_id,
                 "objective": objective,
                 "status": status,
                 "tokensUsed": tokens,
                 "timeUsedSeconds": seconds,
-                "createdAt": 1780272000,
+                "createdAt": created_at,
                 "updatedAt": updated_at,
             },
         },
@@ -88,6 +100,128 @@ class CodexGoalReportTest(unittest.TestCase):
             report = MODULE.collect_local_goals("test-mac", root, MODULE.parse_since("2026-07-01"))
         self.assertEqual(report["goals"], [])
 
+    def test_activity_window_includes_old_goal_resumed_inside_exact_bounds(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            write_session(
+                root / "resume.jsonl",
+                [
+                    goal_event(
+                        "2026-09-08T04:15:59Z",
+                        "Old resumed goal",
+                        "active",
+                        20,
+                        40,
+                        1788840959,
+                    ),
+                    goal_event(
+                        "2026-09-08T04:16:03Z",
+                        "Boundary excluded",
+                        "complete",
+                        30,
+                        50,
+                        1788840963,
+                        thread_id="thread-2",
+                    ),
+                ],
+            )
+            report = MODULE.collect_local_goals(
+                "test-mac",
+                root,
+                MODULE.parse_bound("2026-09-08T04:00:00Z"),
+                MODULE.parse_bound("2026-09-08T04:16:03Z"),
+                True,
+            )
+        self.assertEqual([goal["objective"] for goal in report["goals"]], ["Old resumed goal"])
+        self.assertEqual(report["selection_mode"], "activity")
+
+    def test_sqlite_reports_child_identity_without_changing_lifetime_counters(self):
+        with tempfile.TemporaryDirectory() as directory:
+            codex_home = pathlib.Path(directory)
+            goals = sqlite3.connect(codex_home / "goals_1.sqlite")
+            goals.execute(
+                "CREATE TABLE thread_goals "
+                "(thread_id TEXT, goal_id TEXT, objective TEXT, status TEXT, tokens_used INTEGER, "
+                "time_used_seconds INTEGER, created_at_ms INTEGER, updated_at_ms INTEGER)"
+            )
+            goals.execute(
+                "INSERT INTO thread_goals VALUES (?,?,?,?,?,?,?,?)",
+                ("child-1", "goal-1", "Child work", "complete", 100, 10, 1780272000000, 1788840900000),
+            )
+            goals.commit()
+            goals.close()
+            state = sqlite3.connect(codex_home / "state_5.sqlite")
+            state.execute(
+                "CREATE TABLE threads "
+                "(id TEXT, rollout_path TEXT, created_at INTEGER, updated_at INTEGER, "
+                "created_at_ms INTEGER, updated_at_ms INTEGER, source TEXT, thread_source TEXT)"
+            )
+            state.execute(
+                "INSERT INTO threads VALUES (?,?,?,?,?,?,?,?)",
+                (
+                    "child-1",
+                    "/tmp/child.jsonl",
+                    0,
+                    0,
+                    1780272000000,
+                    1788840900000,
+                    '{"subagent":{"thread_spawn":{"parent_thread_id":"root-1"}}}',
+                    "subagent",
+                ),
+            )
+            state.commit()
+            state.close()
+            report = MODULE.collect_sqlite_goals(
+                "test-mac",
+                codex_home,
+                MODULE.parse_bound("2026-09-08T00:00:00Z"),
+                MODULE.parse_bound("2026-09-09T00:00:00Z"),
+                True,
+            )
+        goal = report["goals"][0]
+        self.assertEqual(goal["thread_role"], "child")
+        self.assertEqual(goal["parent_thread_id"], "root-1")
+        self.assertEqual(goal["counter_scope"], "lifetime_snapshot")
+
+    def test_counter_cursor_reports_deltas_and_resets(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cursor = pathlib.Path(directory) / "cursor.json"
+            report = {"machines": [{"machine": "one", "goals": [{
+                "machine": "one",
+                "thread_id": "thread-1",
+                "tokens_used": 100,
+                "goal_time_seconds": 20,
+            }]}]}
+            MODULE.apply_counter_cursor(report, cursor, 10)
+            self.assertIsNone(report["machines"][0]["goals"][0]["counter_delta"]["tokens"])
+
+            report["machines"][0]["goals"][0].update(tokens_used=140, goal_time_seconds=5)
+            MODULE.apply_counter_cursor(report, cursor, 10)
+            delta = report["machines"][0]["goals"][0]["counter_delta"]
+        self.assertEqual(delta["tokens"], 40)
+        self.assertTrue(delta["goal_time_reset"])
+        self.assertIsNone(delta["goal_time_seconds"])
+
+    def test_partial_fleet_coverage_exits_nonzero_after_rendering(self):
+        with tempfile.TemporaryDirectory() as directory:
+            policy = pathlib.Path(directory) / "policy.json"
+            policy.write_text('{"systems":{}}')
+            payload = {
+                "generated_at": "2026-09-08T00:00:00Z",
+                "machines": [{"machine": "offline", "error": "timed out", "goals": []}],
+            }
+            with mock.patch.object(MODULE, "collect_fleet", return_value=payload):
+                with mock.patch.object(sys, "argv", [
+                    "codex-goal-report.py",
+                    "--fleet",
+                    "--policy",
+                    str(policy),
+                    "--json",
+                ]):
+                    with mock.patch.object(sys, "stdout"):
+                        status = MODULE.main()
+        self.assertEqual(status, 2)
+
     def test_markdown_surfaces_repeated_goals_and_failures(self):
         goal = {
             "machine": "one",
@@ -110,7 +244,7 @@ class CodexGoalReportTest(unittest.TestCase):
         output = MODULE.markdown_report(report)
         self.assertIn("**2 runs** — retest beta", output)
         self.assertIn("**offline**: connection timed out", output)
-        self.assertIn("Total Codex goal time: 2m", output)
+        self.assertIn("Lifetime goal-time snapshots: 2m", output)
 
 
 if __name__ == "__main__":

--- a/skills/codex-goal-mining/scripts/codex-goal-report-test.py
+++ b/skills/codex-goal-mining/scripts/codex-goal-report-test.py
@@ -135,6 +135,13 @@ class CodexGoalReportTest(unittest.TestCase):
         self.assertEqual([goal["objective"] for goal in report["goals"]], ["Old resumed goal"])
         self.assertEqual(report["selection_mode"], "activity")
 
+    def test_activity_window_excludes_goal_updated_at_upper_bound(self):
+        created = MODULE.parse_bound("2026-09-01T00:00:00Z")
+        updated = MODULE.parse_bound("2026-09-08T04:16:03Z")
+        since = MODULE.parse_bound("2026-09-08T04:00:00Z")
+        until = MODULE.parse_bound("2026-09-08T04:16:03Z")
+        self.assertFalse(MODULE.in_window(created, updated, since, until, True))
+
     def test_sqlite_reports_child_identity_without_changing_lifetime_counters(self):
         with tempfile.TemporaryDirectory() as directory:
             codex_home = pathlib.Path(directory)

--- a/skills/codex-goal-mining/scripts/codex-goal-report.py
+++ b/skills/codex-goal-mining/scripts/codex-goal-report.py
@@ -136,10 +136,8 @@ def in_window(
     selected = updated_at if activity_overlap else created_at
     if since and (selected is None or selected < since):
         return False
-    if until:
-        boundary_value = created_at if activity_overlap else selected
-        if boundary_value is None or boundary_value >= until:
-            return False
+    if until and (selected is None or selected >= until):
+        return False
     return True
 
 

--- a/skills/codex-goal-mining/scripts/codex-goal-report.py
+++ b/skills/codex-goal-mining/scripts/codex-goal-report.py
@@ -72,6 +72,26 @@ def normalize_objective(value: str) -> str:
     return " ".join(value.lower().split())
 
 
+def thread_identity(thread: sqlite3.Row | None) -> tuple[str, str | None]:
+    if thread is None:
+        return "unknown", None
+    keys = set(thread.keys())
+    thread_source = str(thread["thread_source"] or "") if "thread_source" in keys else ""
+    source = thread["source"] if "source" in keys else None
+    parent_thread_id = None
+    if isinstance(source, str) and source.startswith("{"):
+        try:
+            source_value = json.loads(source)
+        except json.JSONDecodeError:
+            source_value = {}
+        subagent = source_value.get("subagent") if isinstance(source_value, dict) else None
+        if isinstance(subagent, dict):
+            spawn = subagent.get("thread_spawn")
+            if isinstance(spawn, dict) and spawn.get("parent_thread_id"):
+                parent_thread_id = str(spawn["parent_thread_id"])
+    return ("child", parent_thread_id) if thread_source == "subagent" else ("root", None)
+
+
 def candidate_goal_files(sessions_root: pathlib.Path) -> list[pathlib.Path]:
     if not sessions_root.exists():
         return []
@@ -106,7 +126,30 @@ def find_database(codex_home: pathlib.Path, name: str, required_table: str) -> p
     return max(valid, key=lambda path: path.stat().st_mtime) if valid else None
 
 
-def collect_sqlite_goals(machine: str, codex_home: pathlib.Path, since: datetime | None) -> dict[str, Any] | None:
+def in_window(
+    created_at: datetime | None,
+    updated_at: datetime | None,
+    since: datetime | None,
+    until: datetime | None,
+    activity_overlap: bool,
+) -> bool:
+    selected = updated_at if activity_overlap else created_at
+    if since and (selected is None or selected < since):
+        return False
+    if until:
+        boundary_value = created_at if activity_overlap else selected
+        if boundary_value is None or boundary_value >= until:
+            return False
+    return True
+
+
+def collect_sqlite_goals(
+    machine: str,
+    codex_home: pathlib.Path,
+    since: datetime | None,
+    until: datetime | None = None,
+    activity_overlap: bool = False,
+) -> dict[str, Any] | None:
     goals_db = find_database(codex_home, "goals_1.sqlite", "thread_goals")
     if goals_db is None:
         return None
@@ -114,13 +157,26 @@ def collect_sqlite_goals(machine: str, codex_home: pathlib.Path, since: datetime
     try:
         goals_connection = sqlite3.connect(f"file:{goals_db}?mode=ro", uri=True, timeout=4)
         goals_connection.row_factory = sqlite3.Row
+        goal_columns = {
+            row[1] for row in goals_connection.execute("PRAGMA table_info(thread_goals)")
+        }
+        selected_goal_columns = [
+            name
+            for name in (
+                "thread_id",
+                "goal_id",
+                "objective",
+                "status",
+                "tokens_used",
+                "time_used_seconds",
+                "created_at_ms",
+                "updated_at_ms",
+            )
+            if name in goal_columns
+        ]
         rows = goals_connection.execute(
-            """
-            SELECT thread_id, objective, status, tokens_used, time_used_seconds,
-                   created_at_ms, updated_at_ms
-            FROM thread_goals
-            ORDER BY created_at_ms DESC
-            """
+            f"SELECT {','.join(selected_goal_columns)} FROM thread_goals "
+            "ORDER BY created_at_ms DESC"
         ).fetchall()
         goals_connection.close()
     except sqlite3.Error:
@@ -131,6 +187,23 @@ def collect_sqlite_goals(machine: str, codex_home: pathlib.Path, since: datetime
         try:
             state_connection = sqlite3.connect(f"file:{state_db}?mode=ro", uri=True, timeout=4)
             state_connection.row_factory = sqlite3.Row
+            thread_columns = {
+                row[1] for row in state_connection.execute("PRAGMA table_info(threads)")
+            }
+            selected_columns = [
+                name
+                for name in (
+                    "id",
+                    "rollout_path",
+                    "created_at",
+                    "updated_at",
+                    "created_at_ms",
+                    "updated_at_ms",
+                    "source",
+                    "thread_source",
+                )
+                if name in thread_columns
+            ]
             thread_ids = [row["thread_id"] for row in rows]
             for offset in range(0, len(thread_ids), 400):
                 batch = thread_ids[offset : offset + 400]
@@ -138,10 +211,8 @@ def collect_sqlite_goals(machine: str, codex_home: pathlib.Path, since: datetime
                 if not placeholders:
                     continue
                 for row in state_connection.execute(
-                    f"""
-                    SELECT id, rollout_path, created_at, updated_at, created_at_ms, updated_at_ms
-                    FROM threads WHERE id IN ({placeholders})
-                    """,
+                    f"SELECT {','.join(selected_columns)} FROM threads "
+                    f"WHERE id IN ({placeholders})",
                     batch,
                 ):
                     threads[row["id"]] = row
@@ -152,10 +223,11 @@ def collect_sqlite_goals(machine: str, codex_home: pathlib.Path, since: datetime
     goals = []
     for row in rows:
         created_at = datetime.fromtimestamp(row["created_at_ms"] / 1000, timezone.utc)
-        if since and created_at < since:
-            continue
         updated_at = datetime.fromtimestamp(row["updated_at_ms"] / 1000, timezone.utc)
+        if not in_window(created_at, updated_at, since, until, activity_overlap):
+            continue
         thread = threads.get(row["thread_id"])
+        thread_role, parent_thread_id = thread_identity(thread)
         session_start = None
         session_end = None
         sources = []
@@ -170,6 +242,7 @@ def collect_sqlite_goals(machine: str, codex_home: pathlib.Path, since: datetime
             {
                 "machine": machine,
                 "thread_id": row["thread_id"],
+                "goal_id": row["goal_id"] if "goal_id" in row.keys() else None,
                 "objective": row["objective"],
                 "status": row["status"],
                 "tokens_used": int(row["tokens_used"] or 0),
@@ -180,6 +253,9 @@ def collect_sqlite_goals(machine: str, codex_home: pathlib.Path, since: datetime
                 "session_ended_at": format_timestamp(session_end),
                 "session_span_seconds": int((session_end - session_start).total_seconds()) if session_start and session_end else 0,
                 "source_files": sources,
+                "thread_role": thread_role,
+                "parent_thread_id": parent_thread_id,
+                "counter_scope": "lifetime_snapshot",
             }
         )
     return {
@@ -187,6 +263,7 @@ def collect_sqlite_goals(machine: str, codex_home: pathlib.Path, since: datetime
         "storage": "sqlite",
         "goals_database": str(goals_db),
         "state_database": str(state_db) if state_db else None,
+        "selection_mode": "activity" if activity_overlap else "created",
         "goals": goals,
     }
 
@@ -199,8 +276,14 @@ def event_key(goal: dict[str, Any], fallback_thread_id: str) -> tuple[str, int, 
     )
 
 
-def collect_local_goals(machine: str, sessions_root: pathlib.Path, since: datetime | None = None) -> dict[str, Any]:
-    database_report = collect_sqlite_goals(machine, sessions_root.parent, since)
+def collect_local_goals(
+    machine: str,
+    sessions_root: pathlib.Path,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    activity_overlap: bool = False,
+) -> dict[str, Any]:
+    database_report = collect_sqlite_goals(machine, sessions_root.parent, since, until, activity_overlap)
     if database_report is not None:
         return database_report
     goals: dict[tuple[str, int, str], dict[str, Any]] = {}
@@ -234,13 +317,20 @@ def collect_local_goals(machine: str, sessions_root: pathlib.Path, since: dateti
                         continue
                     key = event_key(goal, str(payload.get("threadId") or ""))
                     created_at = datetime.fromtimestamp(int(goal.get("createdAt") or 0), timezone.utc) if goal.get("createdAt") else timestamp
-                    if since and created_at and created_at < since:
+                    updated_at = int(goal.get("updatedAt") or 0)
+                    event_updated_at = datetime.fromtimestamp(updated_at, timezone.utc) if updated_at else timestamp
+                    if activity_overlap:
+                        if since and (event_updated_at is None or event_updated_at < since):
+                            continue
+                        if until and (event_updated_at is None or event_updated_at >= until):
+                            continue
+                    elif not in_window(created_at, event_updated_at, since, until, False):
                         continue
                     current = goals.get(key)
-                    updated_at = int(goal.get("updatedAt") or 0)
                     snapshot = {
                         "machine": machine,
                         "thread_id": key[0],
+                        "goal_id": str(goal.get("id") or f"{key[1]}:{key[2]}"),
                         "objective": objective,
                         "status": str(goal.get("status") or "unknown"),
                         "tokens_used": int(goal.get("tokensUsed") or 0),
@@ -253,6 +343,9 @@ def collect_local_goals(machine: str, sessions_root: pathlib.Path, since: dateti
                         "session_ended_at": format_timestamp(file_end),
                         "session_span_seconds": 0,
                         "source_files": [str(path)],
+                        "thread_role": "unknown",
+                        "parent_thread_id": None,
+                        "counter_scope": "lifetime_snapshot",
                         "_updated_epoch": updated_at,
                         "_session_start": file_start,
                         "_session_end": file_end,
@@ -301,6 +394,7 @@ def collect_local_goals(machine: str, sessions_root: pathlib.Path, since: dateti
         "sessions_root": str(sessions_root),
         "files_scanned": files_scanned,
         "parse_errors": parse_errors,
+        "selection_mode": "activity" if activity_overlap else "created",
         "goals": output,
     }
 
@@ -313,19 +407,48 @@ def fleet_targets(policy_path: pathlib.Path, selected: set[str] | None = None) -
         if selected and alias not in selected and wsl_alias not in selected:
             continue
         if not selected or alias in selected:
-            targets.append({"machine": alias, "ssh_target": system.get("ssh_target")})
+            targets.append(
+                {
+                    "machine": alias,
+                    "ssh_target": system.get("ssh_target"),
+                    "interpreter": system.get("python"),
+                }
+            )
         wsl_target = system.get("wsl_target")
         if wsl_target and (not selected or alias in selected or wsl_alias in selected):
-            targets.append({"machine": wsl_alias, "ssh_target": wsl_target})
+            targets.append(
+                {
+                    "machine": wsl_alias,
+                    "ssh_target": wsl_target,
+                    "interpreter": system.get("wsl_python"),
+                }
+            )
     return targets
 
 
-def collect_remote(script: bytes, machine: str, ssh_target: str, since: str | None, timeout: int) -> dict[str, Any]:
+def collect_remote(
+    script: bytes,
+    machine: str,
+    ssh_target: str,
+    since: str | None,
+    until: str | None,
+    activity_overlap: bool,
+    timeout: int,
+    interpreter: str | None = None,
+    one_attempt: bool = False,
+) -> dict[str, Any]:
     arguments = ["--collect-local", "--machine-name", machine, "--json"]
     if since:
         arguments.extend(["--since", since])
+    if until:
+        arguments.extend(["--until", until])
+    if activity_overlap:
+        arguments.append("--activity-overlap")
     failures = []
-    for interpreter in ("python3", "python", "py -3"):
+    interpreters = [interpreter] if interpreter else ["python3", "python", "py -3"]
+    if one_attempt:
+        interpreters = interpreters[:1]
+    for selected_interpreter in interpreters:
         command = [
             "ssh",
             "-o", "BatchMode=yes",
@@ -333,38 +456,149 @@ def collect_remote(script: bytes, machine: str, ssh_target: str, since: str | No
             "-o", "ServerAliveInterval=15",
             "-o", "ServerAliveCountMax=3",
             ssh_target,
-            shlex.join([*shlex.split(interpreter), "-", *arguments]),
+            shlex.join([*shlex.split(selected_interpreter), "-", *arguments]),
         ]
         try:
             result = subprocess.run(command, input=script, capture_output=True, timeout=timeout + 20)
         except subprocess.TimeoutExpired:
-            failures.append(f"{interpreter}: timed out")
+            failures.append(f"{selected_interpreter}: timed out")
             continue
         if result.returncode == 0:
             try:
                 return json.loads(result.stdout.decode())
             except json.JSONDecodeError as error:
-                failures.append(f"{interpreter}: invalid JSON ({error})")
+                failures.append(f"{selected_interpreter}: invalid JSON ({error})")
                 continue
         detail = result.stderr.decode(errors="replace").strip() or result.stdout.decode(errors="replace").strip()
         detail = detail.replace(ssh_target, machine)
-        failures.append(f"{interpreter}: {detail or f'exit {result.returncode}'}")
+        failures.append(f"{selected_interpreter}: {detail or f'exit {result.returncode}'}")
         if "timed out" in detail.lower() or "connection" in detail.lower():
             break
     return {"machine": machine, "error": "; ".join(failures), "goals": []}
 
 
-def collect_fleet(policy_path: pathlib.Path, selected: set[str] | None, since: datetime | None, timeout: int) -> dict[str, Any]:
+def collect_fleet(
+    policy_path: pathlib.Path,
+    selected: set[str] | None,
+    since: datetime | None,
+    until: datetime | None,
+    activity_overlap: bool,
+    timeout: int,
+    one_attempt: bool = False,
+) -> dict[str, Any]:
     script = pathlib.Path(__file__).read_bytes()
     machines = []
     for target in fleet_targets(policy_path, selected):
         machine = str(target["machine"])
         ssh_target = target["ssh_target"]
         if ssh_target:
-            machines.append(collect_remote(script, machine, str(ssh_target), since.date().isoformat() if since else None, timeout))
+            machines.append(
+                collect_remote(
+                    script,
+                    machine,
+                    str(ssh_target),
+                    format_timestamp(since),
+                    format_timestamp(until),
+                    activity_overlap,
+                    timeout,
+                    target.get("interpreter"),
+                    one_attempt,
+                )
+            )
         else:
-            machines.append(collect_local_goals(machine, pathlib.Path.home() / ".codex" / "sessions", since))
-    return {"generated_at": format_timestamp(datetime.now(timezone.utc)), "machines": machines}
+            machines.append(
+                collect_local_goals(
+                    machine,
+                    pathlib.Path.home() / ".codex" / "sessions",
+                    since,
+                    until,
+                    activity_overlap,
+                )
+            )
+    failed = [machine["machine"] for machine in machines if machine.get("error")]
+    reached = [machine["machine"] for machine in machines if not machine.get("error")]
+    return {
+        "generated_at": format_timestamp(datetime.now(timezone.utc)),
+        "window": {
+            "since": format_timestamp(since),
+            "until": format_timestamp(until),
+            "selection": "activity" if activity_overlap else "created",
+        },
+        "coverage": {
+            "expected": [machine["machine"] for machine in machines],
+            "reached": reached,
+            "failed": failed,
+            "complete": not failed,
+        },
+        "machines": machines,
+    }
+
+
+def apply_counter_cursor(
+    report: dict[str, Any],
+    cursor_path: pathlib.Path,
+    max_entries: int,
+) -> None:
+    try:
+        cursor = json.loads(cursor_path.read_text()) if cursor_path.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        cursor = {}
+    previous_entries = cursor.get("entries") if isinstance(cursor.get("entries"), dict) else {}
+    captured_at = format_timestamp(datetime.now(timezone.utc))
+    next_entries: dict[str, Any] = {}
+    for goal in flatten_goals(report):
+        goal_identity = goal.get("goal_id") or normalize_objective(goal.get("objective") or "")
+        key = f"{goal['machine']}:{goal['thread_id']}:{goal_identity}"
+        previous = previous_entries.get(key)
+        current_tokens = int(goal.get("tokens_used") or 0)
+        current_seconds = int(goal.get("goal_time_seconds") or 0)
+        token_reset = bool(previous and current_tokens < int(previous.get("tokens_used") or 0))
+        time_reset = bool(previous and current_seconds < int(previous.get("goal_time_seconds") or 0))
+        goal["counter_delta"] = {
+            "from_capture": previous.get("captured_at") if previous else None,
+            "to_capture": captured_at,
+            "tokens": (
+                current_tokens - int(previous.get("tokens_used") or 0)
+                if previous and not token_reset
+                else None
+            ),
+            "goal_time_seconds": (
+                current_seconds - int(previous.get("goal_time_seconds") or 0)
+                if previous and not time_reset
+                else None
+            ),
+            "tokens_reset": token_reset,
+            "goal_time_reset": time_reset,
+        }
+        next_entries[key] = {
+            "machine": goal["machine"],
+            "thread_id": goal["thread_id"],
+            "goal_id": goal.get("goal_id"),
+            "captured_at": captured_at,
+            "tokens_used": current_tokens,
+            "goal_time_seconds": current_seconds,
+            "updated_at": goal.get("updated_at"),
+        }
+    combined = {**previous_entries, **next_entries}
+    retained = sorted(
+        combined.items(),
+        key=lambda item: (item[1].get("captured_at") or "", item[0]),
+        reverse=True,
+    )[:max_entries]
+    cursor_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = cursor_path.with_name(f".{cursor_path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps({"version": 1, "captured_at": captured_at, "entries": dict(retained)}, indent=2)
+        + "\n"
+    )
+    temporary.replace(cursor_path)
+    report["counter_cursor"] = {
+        "path": str(cursor_path),
+        "captured_at": captured_at,
+        "entry_count": len(retained),
+        "max_entries": max_entries,
+        "basis": "delta from the previous captured lifetime snapshot",
+    }
 
 
 def flatten_goals(report: dict[str, Any]) -> list[dict[str, Any]]:
@@ -381,15 +615,34 @@ def markdown_report(report: dict[str, Any]) -> str:
         "# Codex Fleet Goal Report",
         "",
         f"Generated: {report.get('generated_at')}",
+        f"Window: {report.get('window', {}).get('since') or 'unbounded'} to "
+        f"{report.get('window', {}).get('until') or 'now'} "
+        f"({report.get('window', {}).get('selection', 'created')})",
         "",
         "## Summary",
         "",
         f"- Goals: {len(goals)}",
         f"- Machines reached: {len(reachable)}/{len(report.get('machines', []))}",
-        f"- Total Codex goal time: {format_duration(total_goal_time)}",
+        f"- Lifetime goal-time snapshots: {format_duration(total_goal_time)}",
         f"- Summed wall-clock thread spans: {format_duration(total_session_span)} (includes idle/resume gaps)",
-        f"- Total tokens recorded: {sum(goal.get('tokens_used', 0) for goal in goals):,}",
+        f"- Lifetime token snapshots: {sum(goal.get('tokens_used', 0) for goal in goals):,}",
     ]
+    deltas = [goal.get("counter_delta") for goal in goals if goal.get("counter_delta")]
+    token_deltas = [delta["tokens"] for delta in deltas if delta.get("tokens") is not None]
+    time_deltas = [
+        delta["goal_time_seconds"]
+        for delta in deltas
+        if delta.get("goal_time_seconds") is not None
+    ]
+    if deltas:
+        lines.extend(
+            [
+                f"- Incremental token delta: {sum(token_deltas):,} "
+                f"({len(token_deltas)}/{len(deltas)} goals had a prior baseline)",
+                f"- Incremental goal-time delta: {format_duration(sum(time_deltas))} "
+                f"({len(time_deltas)}/{len(deltas)} goals had a prior baseline)",
+            ]
+        )
     if unreachable:
         lines.extend(["", "## Unreachable", ""])
         for machine in unreachable:
@@ -411,9 +664,10 @@ def markdown_report(report: dict[str, Any]) -> str:
                 goal["objective"],
                 "",
                 f"- Status: {goal['status']}",
-                f"- Goal time: {format_duration(goal['goal_time_seconds'])}",
+                f"- Goal time snapshot: {format_duration(goal['goal_time_seconds'])}",
                 f"- Wall-clock thread span: {format_duration(goal['session_span_seconds'])} (includes idle/resume gaps)",
-                f"- Tokens: {goal['tokens_used']:,}",
+                f"- Token snapshot: {goal['tokens_used']:,}",
+                f"- Thread role: {goal.get('thread_role', 'unknown')}",
                 f"- Thread: `{goal['thread_id']}`",
                 "",
             ]
@@ -421,11 +675,14 @@ def markdown_report(report: dict[str, Any]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def parse_since(value: str | None) -> datetime | None:
+def parse_bound(value: str | None) -> datetime | None:
     if not value:
         return None
-    parsed = datetime.fromisoformat(value)
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     return parsed.replace(tzinfo=parsed.tzinfo or timezone.utc).astimezone(timezone.utc)
+
+
+parse_since = parse_bound
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -433,10 +690,32 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--policy", type=pathlib.Path, default=DEFAULT_POLICY, help="Fleet policy JSON; omit for local collection.")
     parser.add_argument("--machine", action="append", help="Fleet alias to include; repeat to select several.")
     parser.add_argument("--since", help="Only include goals created on or after this ISO date/time.")
+    parser.add_argument("--until", help="Exclusive ISO date/time upper bound.")
+    parser.add_argument(
+        "--activity-overlap",
+        action="store_true",
+        help="Select goals updated in the window instead of changing the existing creation-time semantics.",
+    )
     parser.add_argument("--ssh-timeout", type=int, default=8)
+    parser.add_argument(
+        "--one-attempt",
+        action="store_true",
+        help="Try only the configured or first remote interpreter for each fleet target.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit JSON instead of Markdown.")
     parser.add_argument("--output", type=pathlib.Path, help="Write the report to a file instead of stdout.")
     parser.add_argument("--local", action="store_true", help="Collect only this machine instead of the configured fleet.")
+    parser.add_argument(
+        "--fleet",
+        action="store_true",
+        help="Require configured fleet collection; fail if no fleet policy is available.",
+    )
+    parser.add_argument(
+        "--cursor-file",
+        type=pathlib.Path,
+        help="Optional bounded counter snapshot for reset-safe deltas. No cursor is written by default.",
+    )
+    parser.add_argument("--cursor-max-entries", type=int, default=10_000)
     parser.add_argument("--collect-local", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--machine-name", default=os.environ.get("HOSTNAME") or "local", help=argparse.SUPPRESS)
     parser.add_argument("--sessions-root", type=pathlib.Path, default=pathlib.Path.home() / ".codex" / "sessions", help=argparse.SUPPRESS)
@@ -446,23 +725,68 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
-    since = parse_since(args.since)
+    since = parse_bound(args.since)
+    until = parse_bound(args.until)
+    if since and until and until <= since:
+        parser.error("--until must be later than --since")
+    if args.cursor_max_entries < 1:
+        parser.error("--cursor-max-entries must be positive")
+    if args.fleet and args.local:
+        parser.error("--fleet and --local conflict")
+    if args.fleet and args.policy is None:
+        parser.error("fleet policy is required; pass --policy or set CODEX_FLEET_POLICY")
     if args.collect_local:
-        payload: dict[str, Any] = collect_local_goals(args.machine_name, args.sessions_root, since)
+        payload: dict[str, Any] = collect_local_goals(
+            args.machine_name,
+            args.sessions_root,
+            since,
+            until,
+            args.activity_overlap,
+        )
     elif args.local or args.policy is None:
-        local_report = collect_local_goals(args.machine_name, args.sessions_root, since)
-        payload = {"generated_at": format_timestamp(datetime.now(timezone.utc)), "machines": [local_report]}
+        local_report = collect_local_goals(
+            args.machine_name,
+            args.sessions_root,
+            since,
+            until,
+            args.activity_overlap,
+        )
+        payload = {
+            "generated_at": format_timestamp(datetime.now(timezone.utc)),
+            "window": {
+                "since": format_timestamp(since),
+                "until": format_timestamp(until),
+                "selection": "activity" if args.activity_overlap else "created",
+            },
+            "coverage": {
+                "expected": [local_report["machine"]],
+                "reached": [local_report["machine"]],
+                "failed": [],
+                "complete": True,
+            },
+            "machines": [local_report],
+        }
     else:
         if not args.policy.exists():
             parser.error(f"fleet policy not found: {args.policy}")
-        payload = collect_fleet(args.policy, set(args.machine or []) or None, since, args.ssh_timeout)
+        payload = collect_fleet(
+            args.policy,
+            set(args.machine or []) or None,
+            since,
+            until,
+            args.activity_overlap,
+            args.ssh_timeout,
+            args.one_attempt,
+        )
+    if args.cursor_file:
+        apply_counter_cursor(payload, args.cursor_file, args.cursor_max_entries)
     rendered = json.dumps(payload, indent=2, ensure_ascii=False) + "\n" if args.json else markdown_report(payload)
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(rendered)
     else:
         sys.stdout.write(rendered)
-    return 0
+    return 2 if any(machine.get("error") for machine in payload.get("machines", [])) else 0
 
 
 if __name__ == "__main__":

--- a/skills/operations-worktree/SKILL.md
+++ b/skills/operations-worktree/SKILL.md
@@ -17,22 +17,32 @@ Create and manage worktrees safely and consistently across projects while avoidi
 - You need to avoid branching from stale local `main` or local `HEAD`.
 
 ## Workflow
-1. Ensure you are inside the target repository (main checkout or any linked worktree).
-2. Create a new worktree with the shell wrapper:
+1. Resolve the repository identity, canonical owning checkout, Git common
+   directory, and existing worktree registrations. Preserve dirty owner state.
+2. Verify the owner is healthy and the intended remote base is current. A
+   cached ref is not proof of the latest remote head.
+3. Discover the installed wrapper with `gwt help` and its managed root with
+   `gwt root`.
+4. Create a new worktree with the shell wrapper:
    - `gwt new <branch>`
    - Optional explicit base: `gwt new <branch> <start-point>`
-3. If shell wrappers are unavailable, use raw git safely:
-   - `default=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)`
-   - `base=${default#origin/}`
-   - `git fetch origin "$base" --prune`
-   - `git worktree add -b <branch> <path> "origin/$base"`
-4. For OpenClaw PR review worktrees, prefer that repository's native PR review-init helper instead of hand-assembling refs.
+   Stop if the wrapper is unavailable or refuses the owner. Do not replace it
+   with a raw-Git worktree, copied repository, or ad hoc clone.
+5. Verify the returned path, managed root, registration, branch, exact base,
+   and dependency ownership before editing.
+6. Read `references/task-artifacts.md` before work that retains evidence,
+   publishes expensive artifacts, or needs a resumable phase/blocker receipt.
+7. For OpenClaw, use its current `AGENTS.md` and native review/release lifecycle
+   helpers. Do not override their exact-head or evidence rules here.
+8. Finish with an explicit checkout outcome: `retained`, `blocked`, or verified
+   `removed`. Completion alone does not authorize cleanup.
 
 ## Inputs
 - Branch name (required)
 - Optional start-point (branch/tag/commit)
-- Optional destination path (for raw git mode)
+- Canonical owner and configured managed root
 
 ## Outputs
 - New linked worktree checked out on the target branch.
-- Default base anchored to a fetched remote default branch unless explicitly overridden.
+- Verified owner, managed path, registration, branch, and exact base.
+- Explicit retained, blocked, or verified removed checkout outcome.

--- a/skills/operations-worktree/references/task-artifacts.md
+++ b/skills/operations-worktree/references/task-artifacts.md
@@ -1,0 +1,54 @@
+# Task Checkpoints And Artifacts
+
+Use the task's existing state or result channel. Do not add a supervisor,
+telemetry daemon, or persistent receipt tree merely to say that nothing was
+retained.
+
+## Default
+
+- Return ordinary audit and discovery results through stdout, stderr, structured
+  JSON, or an existing required task-state store.
+- Use run-owned temporary scratch only when the tool needs files to execute.
+- Create no persistent artifact root unless retention is required or explicitly
+  selected.
+- Preserve the original owner, failure, exit status, and user-owned paths when
+  checkpoint or artifact delivery fails.
+
+## Declared Retention
+
+Before expensive work, declare:
+
+- artifact root and owner;
+- source and input identity;
+- output kind and required or optional status;
+- maximum retained files and bytes;
+- retention or pin intent;
+- approved publication destination, when one exists.
+
+Keep temporary scratch separate from retained evidence. Refuse the optional
+stage before work when its declared budget or destination is invalid. Report
+`artifact-budget-exceeded` without hiding the original failure.
+
+Store a small checkpoint in the existing task-state route when continuation
+needs it. The checkpoint should contain the task owner, source/input identity,
+acceptance criteria, completed phases, last material artifact, external
+blocker, failure fingerprint, retry allowance, and the event that permits a
+retry. An unchanged blocker must not create another root, worktree, lease, or
+download.
+
+## Reuse And Ordering
+
+- Reuse immutable large inputs, inventories, and completed evidence only when
+  their source/input identity still matches.
+- Keep one canonical large output and use compatible references or derived
+  views. Do not duplicate bytes or share mutable hard links across runs.
+- Publish required release, security, hardware, or canonical worker evidence
+  before optional profiling, long handover, or lease expiry.
+- Verify checksum and retrieval from the already approved destination before
+  treating publication as complete.
+- If required publication fails, preserve the expensive local result and block
+  only the optional follow-on phase.
+
+For OpenClaw, its current repository instructions and native lifecycle state
+remain authoritative. This contract is an adoption pointer, not a replacement
+for exact-head, release, security, or owner checks.

--- a/skills/technical-skill-finder/SKILL.md
+++ b/skills/technical-skill-finder/SKILL.md
@@ -48,13 +48,16 @@ Find recurring pain points from local agent logs and convert them into actionabl
    - If no overlap, propose **new skill**.
 5. Emit ranking output
    - Provide `impact`, `frequency`, `confidence`, `skill-fit`, and first-apply command set.
-6. Produce minimal first-iteration artifacts for high-priority candidates
+6. Produce minimal first-iteration output for high-priority candidates
    - Candidate title + scope
    - Trigger phrase examples
    - Required inputs
    - Suggested workflow summary
    - Evidence snippets (line/file-level)
    - Suggested dependencies/tools (e.g., `jq`, `rg`, shell utilities, MCP resources)
+   - Return this through chat/stdout by default. Create a persistent artifact
+     root only when the user selects one or another required workflow declares
+     it, with file/byte budgets and source/input identity.
 7. Optional extension to personal-signal sources
    - Only after explicit approval to read personal channels.
    - If MCP is available and user has granted access, run MCP resource discovery and include message-signal-derived patterns.
@@ -67,6 +70,9 @@ Find recurring pain points from local agent logs and convert them into actionabl
 - Prefer deterministic commands and small scripts over ad-hoc manual parsing.
 - Always avoid proposing skills with unresolved operational context (credentials, environment, private URLs).
 - If evidence is ambiguous, return `confidence: low` and request one more session sample.
+- Reuse one canonical identity-matched inventory instead of materializing
+  duplicate large extracts. Apply the `$operations-worktree` task artifact
+  contract when retention or resumable phase state is required.
 
 ## Outputs
 

--- a/skills/tmux-agent-lane-orchestrator/SKILL.md
+++ b/skills/tmux-agent-lane-orchestrator/SKILL.md
@@ -28,12 +28,22 @@ Turn a tmux window of coding-agent workers into a visible, auditable lane with c
 2. Capture lane state.
    - `python3 scripts/lane_snapshot.py --lane <number>`
    - Add `--session <name>` outside the active tmux session.
-   - Override `--keywords` for repository-specific log matching.
+   - If a descendant command does not contain its resumed thread ID, repeat
+     `--thread L<number>.<pane>=<thread-id>` from separately verified evidence.
+   - Add `--json` for machine-readable output.
+   - Add `--cursor-file <path>` only when bounded incremental state is wanted;
+     the helper writes no persistent state by default.
 3. Cross-check panes and logs.
    - Pane titles alone are weak evidence.
-   - Compare command, PID, cwd, recent output, and matching `~/.codex/sessions` records.
+   - Resolve pane ID to shell PID, descendant Codex PID, exact thread ID, the
+     state-database rollout path, and the newest turn.
+   - Shared cwd and generic terms such as `CI`, `failed`, or `running` never
+     establish ownership.
+   - Missing or conflicting identity is `unknown`, never a restore target.
 4. Classify each pane.
-   - `active-progress`, `waiting`, `blocked`, `idle`, or `unknown`.
+   - Use the newest exact turn and changing event/tool/token counters.
+   - A completed turn after an earlier error is `completed`, not blocked.
+   - Report bounded bytes read and truncation with the state.
    - Include the evidence and next action, not only the label.
 5. Intervene conservatively.
    - Inspect before steering.
@@ -51,10 +61,12 @@ Read `references/factory-model.md` when designing lane responsibilities or escal
 - tmux session name.
 - Lane number or `L<number>` window.
 - Optional log keywords and capture depth.
+- Optional exact pane/thread declarations and bounded cursor path.
 - Optional operator-provided worker mission map.
 
 ## Outputs
 
-- Current pane and agent-session snapshot.
+- Current pane ID, shell PID, descendant agent PID, exact thread, and rollout snapshot.
 - Per-pane state classification with evidence.
+- Per-file and total log bytes read, cursor mode, and truncation status.
 - Concise manager summary and safe next actions.

--- a/skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot.py
+++ b/skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Snapshot a tmux lane and recent agent logs for lane-manager cold starts."""
+"""Snapshot one tmux lane using exact process/thread identity and bounded log I/O."""
 
 from __future__ import annotations
 
@@ -8,36 +8,44 @@ import datetime as dt
 import json
 import os
 import re
+import sqlite3
 import subprocess
-from collections import deque
+import sys
 from pathlib import Path
 from typing import Any
 
 
+THREAD_ID_RE = re.compile(
+    r"(?<![0-9a-f])([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?![0-9a-f])",
+    re.IGNORECASE,
+)
 SECRET_PATTERNS = (
     re.compile(r"\b(?:gh[opusr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16})\b"),
     re.compile(r"(?i)\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s]+"),
 )
 PRIVATE_IP_PATTERN = re.compile(
-    r"\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])(?:\.\d{1,3}){2})\b"
+    r"\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|172\.(?:1[6-9]|2\d|3[01])"
+    r"(?:\.\d{1,3}){2}|100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])(?:\.\d{1,3}){2})\b"
 )
 
 
-def run_tmux(args: list[str], timeout: int = 5) -> str:
+def run_command(args: list[str], timeout: int = 5) -> str:
     try:
         result = subprocess.run(
-            ["tmux", *args],
+            args,
             check=False,
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=timeout,
         )
-    except subprocess.TimeoutExpired:
+    except (OSError, subprocess.TimeoutExpired):
         return ""
-    if result.returncode != 0:
-        return ""
-    return result.stdout.rstrip("\n")
+    return result.stdout.rstrip("\n") if result.returncode == 0 else ""
+
+
+def run_tmux(args: list[str], timeout: int = 5) -> str:
+    return run_command(["tmux", *args], timeout)
 
 
 def infer_lane() -> tuple[int | None, str]:
@@ -52,19 +60,23 @@ def infer_lane() -> tuple[int | None, str]:
 
 
 def list_lane_panes(session: str, lane: int) -> list[dict[str, str]]:
-    fmt = "#{pane_index}\t#{pane_title}\t#{pane_current_path}\t#{pane_current_command}\t#{pane_pid}\t#{pane_active}"
+    fmt = (
+        "#{pane_id}\t#{pane_index}\t#{pane_title}\t#{pane_current_path}\t"
+        "#{pane_current_command}\t#{pane_pid}\t#{pane_active}"
+    )
     output = run_tmux(["list-panes", "-t", f"{session}:L{lane}", "-F", fmt])
     panes: list[dict[str, str]] = []
     for line in output.splitlines():
-        parts = (line.split("\t") + [""] * 6)[:6]
+        parts = (line.split("\t") + [""] * 7)[:7]
         panes.append(
             {
-                "pane": f"L{lane}.{parts[0]}",
-                "title": parts[1],
-                "cwd": parts[2],
-                "command": parts[3],
-                "pid": parts[4],
-                "active": "yes" if parts[5] == "1" else "no",
+                "pane_id": parts[0],
+                "pane": f"L{lane}.{parts[1]}",
+                "title": parts[2],
+                "cwd": parts[3],
+                "command": parts[4],
+                "pid": parts[5],
+                "active": "yes" if parts[6] == "1" else "no",
             }
         )
     return panes
@@ -73,61 +85,101 @@ def list_lane_panes(session: str, lane: int) -> list[dict[str, str]]:
 def capture_pane(session: str, lane: int, pane: str, lines: int) -> str:
     target = f"{session}:L{lane}.{pane}"
     output = run_tmux(["capture-pane", "-p", "-J", "-S", f"-{lines}", "-t", target])
-    cleaned = "\n".join(line.rstrip() for line in output.splitlines())
-    return cleaned.strip()
+    return "\n".join(line.rstrip() for line in output.splitlines()).strip()
 
 
-def recent_session_dirs(root: Path, max_days: int = 7) -> list[Path]:
+def process_table() -> dict[int, tuple[int, str]]:
+    output = run_command(["ps", "-axo", "pid=,ppid=,command="])
+    processes: dict[int, tuple[int, str]] = {}
+    for line in output.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 2:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        processes[pid] = (ppid, parts[2] if len(parts) == 3 else "")
+    return processes
+
+
+def descendant_processes(root_pid: int, processes: dict[int, tuple[int, str]]) -> list[tuple[int, str]]:
+    children: dict[int, list[int]] = {}
+    for pid, (ppid, _command) in processes.items():
+        children.setdefault(ppid, []).append(pid)
+    pending = list(children.get(root_pid, []))
+    descendants: list[tuple[int, str]] = []
+    while pending:
+        pid = pending.pop(0)
+        descendants.append((pid, processes.get(pid, (0, ""))[1]))
+        pending.extend(children.get(pid, []))
+    return descendants
+
+
+def thread_candidates(root_pid: int, processes: dict[int, tuple[int, str]]) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    for pid, command in descendant_processes(root_pid, processes):
+        if "codex" not in command.lower():
+            continue
+        for thread_id in sorted({match.lower() for match in THREAD_ID_RE.findall(command)}):
+            candidates.append({"pid": pid, "thread_id": thread_id, "command": command})
+    return candidates
+
+
+def codex_descendants(root_pid: int, processes: dict[int, tuple[int, str]]) -> list[tuple[int, str]]:
+    return [
+        (pid, command)
+        for pid, command in descendant_processes(root_pid, processes)
+        if "codex" in command.lower()
+    ]
+
+
+def find_state_database(codex_home: Path) -> Path | None:
+    for path in (codex_home / "state_5.sqlite", codex_home / "sqlite" / "state_5.sqlite"):
+        if path.exists():
+            return path
+    return None
+
+
+def lookup_threads(database: Path | None, thread_ids: set[str]) -> dict[str, dict[str, Any]]:
+    if database is None or not thread_ids:
+        return {}
     try:
-        dirs = [path for path in root.glob("20[0-9][0-9]/*/*") if path.is_dir()]
-    except OSError:
-        return []
-    return sorted(dirs, key=lambda path: path.stat().st_mtime, reverse=True)[:max_days]
-
-
-def recent_codex_logs(limit: int) -> list[Path]:
-    root = Path.home() / ".codex" / "sessions"
-    if not root.exists():
-        return []
-    today = dt.datetime.now().strftime("%Y/%m/%d")
-    today_dir = root / today
-    candidates = list(today_dir.glob("*.jsonl")) if today_dir.exists() else []
-    if len(candidates) < limit:
-        for day_dir in recent_session_dirs(root):
-            if day_dir == today_dir:
-                continue
-            candidates.extend(day_dir.glob("*.jsonl"))
-            if len(candidates) >= limit * 3:
-                break
-    unique = {path.resolve(): path for path in candidates}
-    return sorted(unique.values(), key=lambda path: path.stat().st_mtime, reverse=True)[:limit]
-
-
-def text_from_payload(payload: Any) -> str:
-    if isinstance(payload, str):
-        return payload
-    if isinstance(payload, dict):
-        chunks: list[str] = []
-        for key in ("message", "output", "cmd", "arguments", "text"):
-            value = payload.get(key)
-            if isinstance(value, str):
-                chunks.append(value)
-        content = payload.get("content")
-        if isinstance(content, list):
-            for item in content:
-                if isinstance(item, dict):
-                    value = item.get("text") or item.get("input_text") or item.get("output_text")
-                    if isinstance(value, str):
-                        chunks.append(value)
-        return "\n".join(chunks)
-    return ""
+        connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True, timeout=2)
+        connection.row_factory = sqlite3.Row
+        columns = {row[1] for row in connection.execute("PRAGMA table_info(threads)")}
+        wanted = [
+            name
+            for name in (
+                "id",
+                "rollout_path",
+                "cwd",
+                "source",
+                "parent_thread_id",
+                "forked_from_id",
+                "updated_at",
+                "updated_at_ms",
+            )
+            if name in columns
+        ]
+        if "id" not in wanted or "rollout_path" not in wanted:
+            connection.close()
+            return {}
+        placeholders = ",".join("?" for _ in thread_ids)
+        rows = connection.execute(
+            f"SELECT {','.join(wanted)} FROM threads WHERE id IN ({placeholders})",
+            sorted(thread_ids),
+        ).fetchall()
+        connection.close()
+    except sqlite3.Error:
+        return {}
+    return {str(row["id"]).lower(): dict(row) for row in rows}
 
 
 def compact(text: str, max_len: int = 220) -> str:
     normalized = re.sub(r"\s+", " ", text).strip()
-    if len(normalized) <= max_len:
-        return normalized
-    return normalized[: max_len - 3].rstrip() + "..."
+    return normalized if len(normalized) <= max_len else normalized[: max_len - 3].rstrip() + "..."
 
 
 def redact(text: str) -> str:
@@ -137,174 +189,454 @@ def redact(text: str) -> str:
     return PRIVATE_IP_PATTERN.sub("<private-ip>", redacted)
 
 
-def display_path(path: str, show_content: bool) -> str:
-    return path if show_content else redact(path)
+def parse_assignment(value: str) -> tuple[str, str]:
+    pane, separator, assigned = value.partition("=")
+    if not separator or not pane or not assigned:
+        raise argparse.ArgumentTypeError("expected PANE=VALUE")
+    return pane, assigned
 
 
-def recent_lines(path: Path, max_lines: int = 600) -> list[str]:
+def load_cursor(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {"version": 1, "files": {}}
     try:
-        with path.open("r", encoding="utf-8", errors="replace") as handle:
-            return list(deque(handle, maxlen=max_lines))
-    except OSError:
-        return []
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {"version": 1, "files": {}}
+    if value.get("version") == 1 and isinstance(value.get("files"), dict):
+        return value
+    return {"version": 1, "files": {}}
 
 
-def scan_log_meta(path: Path) -> tuple[str, str]:
-    session_id = ""
-    cwd = ""
+def save_cursor(path: Path | None, cursor: dict[str, Any], max_files: int) -> None:
+    if path is None:
+        return
+    files = cursor.get("files", {})
+    retained = sorted(
+        files.items(),
+        key=lambda item: (item[1].get("last_seen") or "", item[0]),
+        reverse=True,
+    )[:max_files]
+    cursor["files"] = dict(retained)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(json.dumps(cursor, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def _json_records(data: bytes, absolute_start: int, at_eof: bool) -> tuple[list[dict[str, Any]], int, bool]:
+    records: list[dict[str, Any]] = []
+    consumed = 0
+    offset = 0
+    for raw in data.splitlines(keepends=True):
+        has_newline = raw.endswith((b"\n", b"\r"))
+        body = raw.rstrip(b"\r\n")
+        try:
+            item = json.loads(body.decode("utf-8", errors="replace"))
+        except json.JSONDecodeError:
+            if has_newline:
+                consumed = offset + len(raw)
+            elif not at_eof:
+                break
+            offset += len(raw)
+            continue
+        if isinstance(item, dict):
+            records.append(item)
+        consumed = offset + len(raw)
+        offset += len(raw)
+    partial = consumed < len(data)
+    return records, absolute_start + consumed, partial
+
+
+def read_log(
+    path: Path,
+    byte_limit: int,
+    cursor_entry: dict[str, Any] | None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     try:
-        with path.open("r", encoding="utf-8", errors="replace") as handle:
-            for line_number, raw in enumerate(handle, start=1):
-                if line_number > 40:
-                    break
-                try:
-                    item = json.loads(raw)
-                except json.JSONDecodeError:
-                    continue
-                payload = item.get("payload", {})
-                if item.get("type") == "session_meta":
-                    session_id = str(payload.get("id", session_id))
-                    cwd = str(payload.get("cwd", cwd))
-                elif item.get("type") == "turn_context":
-                    cwd = str(payload.get("cwd", cwd))
-    except OSError:
-        return "", ""
-    return session_id, cwd
+        stat = path.stat()
+    except OSError as error:
+        return [], {"path": str(path), "error": str(error), "bytes_read": 0, "truncated": False}
+
+    previous = cursor_entry or {}
+    same_file = previous.get("device") == stat.st_dev and previous.get("inode") == stat.st_ino
+    previous_offset = int(previous.get("offset") or 0)
+    incremental = same_file and 0 <= previous_offset <= stat.st_size
+    if incremental:
+        start = previous_offset
+        requested = min(byte_limit, stat.st_size - start)
+        mode = "unchanged" if requested == 0 else "incremental"
+    else:
+        requested = min(byte_limit, stat.st_size)
+        start = stat.st_size - requested
+        mode = "tail"
+
+    try:
+        with path.open("rb") as handle:
+            handle.seek(start)
+            data = handle.read(requested)
+    except OSError as error:
+        return [], {"path": str(path), "error": str(error), "bytes_read": 0, "truncated": False}
+
+    discarded_prefix = False
+    parse_start = start
+    if mode == "tail" and start > 0 and data:
+        newline = data.find(b"\n")
+        if newline < 0:
+            return [], {
+                "path": str(path),
+                "bytes_read": len(data),
+                "file_size": stat.st_size,
+                "mode": mode,
+                "truncated": True,
+                "partial_record": True,
+                "device": stat.st_dev,
+                "inode": stat.st_ino,
+                "offset": stat.st_size,
+            }
+        parse_start += newline + 1
+        data = data[newline + 1 :]
+        discarded_prefix = True
+
+    records, next_offset, partial = _json_records(data, parse_start, parse_start + len(data) == stat.st_size)
+    if mode == "unchanged":
+        next_offset = stat.st_size
+    truncated = discarded_prefix or start + requested < stat.st_size or partial
+    return records, {
+        "path": str(path),
+        "bytes_read": requested,
+        "file_size": stat.st_size,
+        "mode": mode,
+        "truncated": truncated,
+        "partial_record": partial,
+        "device": stat.st_dev,
+        "inode": stat.st_ino,
+        "offset": next_offset,
+        "bytes_appended": (
+            max(0, stat.st_size - int(previous.get("file_size") or 0))
+            if same_file
+            else stat.st_size
+        ),
+        "last_seen": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
 
 
-def extract_log_hints(
-    paths: list[Path], pane_cwds: set[str], keywords: list[str], show_content: bool
-) -> list[dict[str, str]]:
-    hints: list[dict[str, str]] = []
-    keyword_re = re.compile("|".join(re.escape(k) for k in keywords), re.IGNORECASE) if keywords else None
-    for path in paths:
-        session_id, cwd = scan_log_meta(path)
-        seen: list[str] = []
-        for raw in recent_lines(path):
-            try:
-                item = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            payload = item.get("payload", {})
-            if item.get("type") == "session_meta":
-                session_id = str(payload.get("id", session_id))
-                cwd = str(payload.get("cwd", cwd))
-            elif item.get("type") == "turn_context":
-                cwd = str(payload.get("cwd", cwd))
-                continue
-            elif item.get("type") == "event_msg":
-                if payload.get("type") not in {"agent_message", "user_message"}:
-                    continue
-            elif item.get("type") == "response_item":
-                if payload.get("type") != "message":
-                    continue
-                if payload.get("role") not in {"user", "assistant"}:
-                    continue
-            else:
-                continue
-            text = text_from_payload(payload)
-            if not text:
-                continue
-            cwd_hit = cwd in pane_cwds if cwd else False
-            keyword_hit = bool(keyword_re.search(text)) if keyword_re else False
-            if cwd_hit or keyword_hit:
-                seen.append(compact(text if show_content else redact(text)))
-        if seen:
-            hints.append(
+def payload_text(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    chunks: list[str] = []
+    for key in ("message", "output", "text"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            chunks.append(value)
+    content = payload.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict):
+                value = item.get("text") or item.get("input_text") or item.get("output_text")
+                if isinstance(value, str):
+                    chunks.append(value)
+    return "\n".join(chunks)
+
+
+def summarize_records(records: list[dict[str, Any]], previous: dict[str, Any] | None = None) -> dict[str, Any]:
+    if not records and previous:
+        return {**previous, "changed": False}
+    summary: dict[str, Any] = {
+        "state": "unknown",
+        "turn_id": None,
+        "latest_timestamp": None,
+        "latest": "",
+        "events": 0,
+        "tool_calls": 0,
+        "tool_outputs": 0,
+        "token_updates": 0,
+        "changed": bool(records),
+    }
+    for item in records:
+        kind = str(item.get("type") or "")
+        payload = item.get("payload") if isinstance(item.get("payload"), dict) else {}
+        if item.get("timestamp"):
+            summary["latest_timestamp"] = item["timestamp"]
+        payload_kind = str(payload.get("type") or "")
+        turn_id = payload.get("turn_id") or payload.get("turnId") or payload.get("id")
+        is_boundary = kind == "turn_context" or (kind == "event_msg" and payload_kind == "task_started")
+        if is_boundary and turn_id != summary.get("turn_id"):
+            summary.update(
                 {
-                    "file": str(path),
-                    "session_id": session_id or "(unknown)",
-                    "cwd": cwd or "(unknown)",
-                    "mtime": dt.datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds"),
-                    "latest": seen[-1],
+                    "state": "active-progress",
+                    "turn_id": turn_id,
+                    "latest": "",
+                    "events": 0,
+                    "tool_calls": 0,
+                    "tool_outputs": 0,
+                    "token_updates": 0,
                 }
             )
-    return hints[:12]
+        summary["events"] += 1
+        if kind == "event_msg":
+            if payload_kind == "task_complete":
+                summary["state"] = "completed"
+            elif payload_kind in {"turn_aborted", "stream_error", "error"}:
+                summary["state"] = "failed"
+            elif payload_kind == "token_count":
+                summary["token_updates"] += 1
+            elif payload_kind in {"agent_message", "agent_reasoning"}:
+                summary["state"] = "active-progress"
+        elif kind == "response_item":
+            if payload_kind in {"function_call", "custom_tool_call"}:
+                summary["tool_calls"] += 1
+                summary["state"] = (
+                    "waiting"
+                    if payload.get("name") in {"wait_agent", "write_stdin"}
+                    else "active-progress"
+                )
+            elif payload_kind in {"function_call_output", "custom_tool_call_output"}:
+                summary["tool_outputs"] += 1
+                summary["state"] = "active-progress"
+        text = payload_text(payload)
+        if text:
+            summary["latest"] = compact(text)
+    return summary
 
 
-def guess_state(command: str, capture: str) -> str:
-    lowered = capture.lower()
-    if command in {"zsh", "bash", "sh"} and re.search(r"\n[^ \n].*[>%$#]\s*$", capture):
-        return "idle?"
-    if any(token in lowered for token in ("error:", "failed", "cannot find package", "err_package_path_not_exported")):
-        return "blocked?"
-    if any(token in lowered for token in ("waiting", "watch", "in_progress", "capacity", "running")):
-        return "waiting/progress?"
-    if command and command not in {"zsh", "bash", "sh"}:
-        return "active?"
-    return "unknown"
+def resolve_pane_identity(
+    pane: dict[str, str],
+    processes: dict[int, tuple[int, str]],
+    explicit_threads: dict[str, str],
+    thread_rows: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    keys = (pane["pane"], pane["pane_id"])
+    explicit = next((explicit_threads[key].lower() for key in keys if key in explicit_threads), None)
+    try:
+        root_pid = int(pane["pid"])
+    except ValueError:
+        root_pid = 0
+    candidates = thread_candidates(root_pid, processes) if root_pid else []
+    if explicit:
+        agents = codex_descendants(root_pid, processes) if root_pid else []
+        matching = [candidate for candidate in candidates if candidate["thread_id"] == explicit]
+        agent_pids = sorted({pid for pid, _command in agents})
+        agent_pid = matching[0]["pid"] if len(matching) == 1 else agent_pids[0] if len(agent_pids) == 1 else None
+        source = (
+            "explicit"
+            if agent_pid and (not candidates or len(matching) == 1)
+            else "conflict"
+            if candidates
+            else "agent-pid-ambiguous"
+            if agent_pids
+            else "agent-pid-unproven"
+        )
+        thread_ids = [explicit]
+    else:
+        unique = sorted({candidate["thread_id"] for candidate in candidates})
+        matching = [candidate for candidate in candidates if len(unique) == 1]
+        agent_pid = matching[0]["pid"] if matching else None
+        source = "process-lineage" if len(unique) == 1 else "ambiguous" if unique else "unmatched"
+        thread_ids = unique
+    if source in {
+        "conflict",
+        "ambiguous",
+        "unmatched",
+        "agent-pid-ambiguous",
+        "agent-pid-unproven",
+    }:
+        return {
+            "status": "unknown",
+            "reason": source,
+            "agent_pid": agent_pid,
+            "thread_ids": thread_ids,
+        }
+    thread_id = thread_ids[0]
+    row = thread_rows.get(thread_id)
+    rollout_path = str(row.get("rollout_path") or "") if row else ""
+    if not rollout_path:
+        return {
+            "status": "unknown",
+            "reason": "thread-not-in-state-database",
+            "agent_pid": agent_pid,
+            "thread_ids": [thread_id],
+        }
+    return {
+        "status": "exact",
+        "reason": source,
+        "agent_pid": agent_pid,
+        "thread_id": thread_id,
+        "rollout_path": rollout_path,
+        "thread": row,
+    }
 
 
-def main() -> int:
+def build_snapshot(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
+    session = args.session or run_tmux(["display", "-p", "#{session_name}"]) or os.environ.get("TMUX_SESSION") or ""
+    if not session:
+        raise RuntimeError("cannot determine tmux session")
+    lane = args.lane
+    infer_reason = None
+    if lane is None:
+        lane, infer_reason = infer_lane()
+    if lane is None:
+        raise RuntimeError("pass --lane explicitly")
+    panes = list_lane_panes(session, lane)
+    if not panes:
+        raise RuntimeError(f"no panes found for {session}:L{lane}")
+
+    explicit_threads = dict(args.thread or [])
+    processes = process_table()
+    candidate_ids = set(explicit_threads.values())
+    for pane in panes:
+        try:
+            candidate_ids.update(candidate["thread_id"] for candidate in thread_candidates(int(pane["pid"]), processes))
+        except ValueError:
+            pass
+    state_database = find_state_database(args.codex_home)
+    thread_rows = lookup_threads(state_database, {value.lower() for value in candidate_ids})
+    cursor = load_cursor(args.cursor_file)
+    remaining = args.total_log_bytes
+    output_panes = []
+    total_bytes = 0
+    for pane in panes:
+        identity = resolve_pane_identity(pane, processes, explicit_threads, thread_rows)
+        capture = capture_pane(session, lane, pane["pane"].split(".")[-1], args.capture_lines)
+        last_line = compact(capture.splitlines()[-1] if capture.splitlines() else "")
+        if not args.show_content:
+            last_line = redact(last_line)
+        public_pane = {
+            **pane,
+            "cwd": pane["cwd"] if args.show_content else redact(pane["cwd"]),
+            "title": pane["title"] if args.show_content else redact(pane["title"]),
+        }
+        public_identity = {key: value for key, value in identity.items() if key != "thread"}
+        if not args.show_content and public_identity.get("rollout_path"):
+            public_identity["rollout_path"] = redact(public_identity["rollout_path"])
+        result = {
+            **public_pane,
+            "last": last_line,
+            "identity": public_identity,
+            "state": "unknown",
+        }
+        if identity["status"] == "exact":
+            path = Path(identity["rollout_path"])
+            previous_entry = cursor["files"].get(str(path), {})
+            byte_limit = min(args.log_bytes, remaining)
+            records, io = read_log(path, byte_limit, previous_entry if args.cursor_file else None)
+            remaining -= io["bytes_read"]
+            total_bytes += io["bytes_read"]
+            summary = summarize_records(records, previous_entry.get("summary"))
+            io["summary"] = summary
+            cursor["files"][str(path)] = io
+            result["log"] = {
+                key: redact(value)
+                if key == "path" and isinstance(value, str) and not args.show_content
+                else value
+                for key, value in io.items()
+                if key not in {"device", "inode", "offset", "summary", "last_seen"}
+            }
+            result["activity"] = summary
+            result["state"] = summary["state"]
+        output_panes.append(result)
+
+    snapshot = {
+        "session": session,
+        "lane": lane,
+        "inference": infer_reason,
+        "state_database": (
+            str(state_database)
+            if args.show_content and state_database
+            else redact(str(state_database))
+            if state_database
+            else None
+        ),
+        "io": {
+            "bytes_read": total_bytes,
+            "per_file_limit": args.log_bytes,
+            "total_limit": args.total_log_bytes,
+            "budget_exhausted": remaining == 0,
+        },
+        "panes": output_panes,
+    }
+    return snapshot, cursor
+
+
+def render_text(snapshot: dict[str, Any], show_content: bool) -> str:
+    lines = [f"lane L{snapshot['lane']} snapshot", f"session: {snapshot['session']}", "", "panes:"]
+    for pane in snapshot["panes"]:
+        identity = pane["identity"]
+        cwd = pane["cwd"] if show_content else redact(pane["cwd"])
+        title = pane["title"] if show_content else redact(pane["title"])
+        lines.append(
+            f"- {pane['pane']} pane_id={pane['pane_id']} state={pane['state']} active={pane['active']} "
+            f"cmd={pane['command']} shell_pid={pane['pid']} agent_pid={identity.get('agent_pid') or '-'} "
+            f"identity={identity['status']} cwd={cwd} title={title!r}"
+        )
+        if identity["status"] == "exact":
+            rollout = identity["rollout_path"] if show_content else redact(identity["rollout_path"])
+            lines.append(f"  thread={identity['thread_id']} rollout={rollout}")
+            log = pane.get("log", {})
+            lines.append(
+                f"  log bytes={log.get('bytes_read', 0)} mode={log.get('mode', 'none')} "
+                f"truncated={str(bool(log.get('truncated'))).lower()}"
+            )
+        else:
+            lines.append(f"  identity_reason={identity['reason']}")
+        if pane["last"]:
+            lines.append(f"  last: {pane['last']}")
+    io = snapshot["io"]
+    lines.extend(
+        [
+            "",
+            f"log I/O: bytes={io['bytes_read']} per_file_limit={io['per_file_limit']} "
+            f"total_limit={io['total_limit']} budget_exhausted={str(io['budget_exhausted']).lower()}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--lane", type=int, help="Lane number, e.g. 1 for L1.")
     parser.add_argument("--session", help="tmux session name. Defaults to current session.")
     parser.add_argument("--capture-lines", type=int, default=80)
-    parser.add_argument("--log-limit", type=int, default=12)
+    parser.add_argument("--log-bytes", type=int, default=262_144, help="Maximum bytes read from one exact rollout.")
+    parser.add_argument("--total-log-bytes", type=int, default=1_048_576, help="Maximum rollout bytes read per snapshot.")
+    parser.add_argument("--codex-home", type=Path, default=Path.home() / ".codex", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--thread",
+        action="append",
+        type=parse_assignment,
+        metavar="PANE=THREAD_ID",
+        help="Declare exact pane/thread identity when the descendant command does not contain the thread id.",
+    )
+    parser.add_argument(
+        "--cursor-file",
+        type=Path,
+        help="Optional bounded incremental cursor. No persistent state is written unless this is set.",
+    )
+    parser.add_argument("--cursor-max-files", type=int, default=64, help=argparse.SUPPRESS)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     parser.add_argument(
         "--show-content",
         action="store_true",
         help="Print raw pane, path, and log content instead of privacy-redacted output.",
     )
-    parser.add_argument(
-        "--keywords",
-        default="Codex,Claude,CodeQL,CI,error,failed,waiting,running",
-    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
     args = parser.parse_args()
-
-    session = args.session or run_tmux(["display", "-p", "#{session_name}"]) or os.environ.get("TMUX_SESSION") or ""
-    if not session:
-        print("error: cannot determine tmux session")
+    if args.log_bytes < 1 or args.total_log_bytes < 1 or args.cursor_max_files < 1:
+        parser.error("log and cursor limits must be positive")
+    try:
+        snapshot, cursor = build_snapshot(args)
+    except RuntimeError as error:
+        print(f"error: {error}", file=sys.stderr)
         return 1
-
-    lane = args.lane
-    if lane is None:
-        lane, reason = infer_lane()
-        print(f"infer: {reason}")
-    if lane is None:
-        print("error: pass --lane explicitly")
-        return 1
-
-    panes = list_lane_panes(session, lane)
-    if not panes:
-        print(f"error: no panes found for {session}:L{lane}")
-        return 1
-
-    home = str(Path.home())
-    pane_cwds = {pane["cwd"] for pane in panes if pane["cwd"] and pane["cwd"] != home}
-    keywords = [part.strip() for part in args.keywords.split(",") if part.strip()]
-    log_hints = extract_log_hints(
-        recent_codex_logs(args.log_limit), pane_cwds, keywords, args.show_content
-    )
-
-    print(f"lane L{lane} snapshot")
-    print(f"session: {session}")
-    print()
-    print("panes:")
-    for pane in panes:
-        pane_index = pane["pane"].split(".")[-1]
-        capture = capture_pane(session, lane, pane_index, args.capture_lines)
-        last_line = compact(capture.splitlines()[-1] if capture.splitlines() else "")
-        if not args.show_content:
-            last_line = redact(last_line)
-        state = guess_state(pane["command"], capture)
-        print(
-            f"- {pane['pane']} state={state} active={pane['active']} cmd={pane['command']} "
-            f"pid={pane['pid']} cwd={display_path(pane['cwd'], args.show_content)} "
-            f"title={redact(pane['title']) if not args.show_content else pane['title']!r}"
-        )
-        if last_line:
-            print(f"  last: {last_line}")
-    print()
-    print("codex log hints:")
-    if not log_hints:
-        print("- none found from recent logs")
-    for hint in log_hints:
-        print(
-            f"- {hint['session_id']} cwd={display_path(hint['cwd'], args.show_content)} "
-            f"mtime={hint['mtime']}"
-        )
-        print(f"  latest: {hint['latest']}")
+    save_cursor(args.cursor_file, cursor, args.cursor_max_files)
+    if args.json:
+        print(json.dumps(snapshot, indent=2, ensure_ascii=False))
+    else:
+        sys.stdout.write(render_text(snapshot, args.show_content))
     return 0
 
 

--- a/skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot.py
+++ b/skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot.py
@@ -342,7 +342,7 @@ def payload_text(payload: Any) -> str:
 def summarize_records(records: list[dict[str, Any]], previous: dict[str, Any] | None = None) -> dict[str, Any]:
     if not records and previous:
         return {**previous, "changed": False}
-    summary: dict[str, Any] = {
+    defaults: dict[str, Any] = {
         "state": "unknown",
         "turn_id": None,
         "latest_timestamp": None,
@@ -351,8 +351,9 @@ def summarize_records(records: list[dict[str, Any]], previous: dict[str, Any] | 
         "tool_calls": 0,
         "tool_outputs": 0,
         "token_updates": 0,
-        "changed": bool(records),
+        "changed": False,
     }
+    summary = {**defaults, **(previous or {}), "changed": bool(records)}
     for item in records:
         kind = str(item.get("type") or "")
         payload = item.get("payload") if isinstance(item.get("payload"), dict) else {}
@@ -361,7 +362,7 @@ def summarize_records(records: list[dict[str, Any]], previous: dict[str, Any] | 
         payload_kind = str(payload.get("type") or "")
         turn_id = payload.get("turn_id") or payload.get("turnId") or payload.get("id")
         is_boundary = kind == "turn_context" or (kind == "event_msg" and payload_kind == "task_started")
-        if is_boundary and turn_id != summary.get("turn_id"):
+        if is_boundary and turn_id and turn_id != summary.get("turn_id"):
             summary.update(
                 {
                     "state": "active-progress",
@@ -398,6 +399,14 @@ def summarize_records(records: list[dict[str, Any]], previous: dict[str, Any] | 
         if text:
             summary["latest"] = compact(text)
     return summary
+
+
+def project_activity(summary: dict[str, Any], show_content: bool) -> dict[str, Any]:
+    projected = dict(summary)
+    latest = projected.get("latest")
+    if isinstance(latest, str) and not show_content:
+        projected["latest"] = redact(latest)
+    return projected
 
 
 def resolve_pane_identity(
@@ -523,7 +532,7 @@ def build_snapshot(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, 
             remaining -= io["bytes_read"]
             total_bytes += io["bytes_read"]
             summary = summarize_records(records, previous_entry.get("summary"))
-            io["summary"] = summary
+            io["summary"] = project_activity(summary, False)
             cursor["files"][str(path)] = io
             result["log"] = {
                 key: redact(value)
@@ -532,7 +541,7 @@ def build_snapshot(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, 
                 for key, value in io.items()
                 if key not in {"device", "inode", "offset", "summary", "last_seen"}
             }
-            result["activity"] = summary
+            result["activity"] = project_activity(summary, args.show_content)
             result["state"] = summary["state"]
         output_panes.append(result)
 

--- a/skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot_test.py
+++ b/skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot_test.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).with_name("lane_snapshot.py")
+SPEC = importlib.util.spec_from_file_location("lane_snapshot", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def event(timestamp, kind, payload_kind, **payload):
+    return {
+        "timestamp": timestamp,
+        "type": kind,
+        "payload": {"type": payload_kind, **payload},
+    }
+
+
+class LaneSnapshotTest(unittest.TestCase):
+    def test_tail_read_is_bounded_and_uses_newest_turn(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "rollout.jsonl"
+            old = event("2026-09-01T00:00:00Z", "event_msg", "error", message="old failure")
+            started = event("2026-09-08T00:00:00Z", "event_msg", "task_started", id="turn-2")
+            done = event("2026-09-08T00:01:00Z", "event_msg", "task_complete", message="done")
+            with path.open("wb") as handle:
+                for _ in range(100_000):
+                    handle.write(json.dumps(old).encode() + b"\n")
+                handle.write(json.dumps(started).encode() + b"\n")
+                handle.write(json.dumps(done).encode())
+
+            records, receipt = MODULE.read_log(path, 16_384, None)
+            summary = MODULE.summarize_records(records)
+
+        self.assertLessEqual(receipt["bytes_read"], 16_384)
+        self.assertTrue(receipt["truncated"])
+        self.assertEqual(summary["turn_id"], "turn-2")
+        self.assertEqual(summary["state"], "completed")
+
+    def test_cursor_skips_unchanged_bytes_and_handles_partial_append(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "rollout.jsonl"
+            complete = json.dumps(event("2026-09-08T00:00:00Z", "event_msg", "task_started", id="turn-1"))
+            partial = '{"timestamp":"2026-09-08T00:01:00Z","type":"event_msg"'
+            path.write_text(complete + "\n" + partial)
+
+            first_records, first = MODULE.read_log(path, 4096, None)
+            self.assertEqual(len(first_records), 1)
+            self.assertTrue(first["partial_record"])
+
+            path.write_text(complete + "\n" + partial + ',"payload":{"type":"task_complete"}}')
+            second_records, second = MODULE.read_log(path, 4096, first)
+            second_summary = MODULE.summarize_records(second_records)
+            third_records, third = MODULE.read_log(path, 4096, second)
+
+        self.assertEqual(second["mode"], "incremental")
+        self.assertEqual(second_summary["state"], "completed")
+        self.assertEqual(third_records, [])
+        self.assertEqual(third["bytes_read"], 0)
+        self.assertEqual(third["mode"], "unchanged")
+
+    def test_large_single_record_stays_bounded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "rollout.jsonl"
+            path.write_text(json.dumps({"type": "event_msg", "payload": {"message": "x" * 2_000_000}}))
+            records, receipt = MODULE.read_log(path, 8192, None)
+        self.assertEqual(records, [])
+        self.assertEqual(receipt["bytes_read"], 8192)
+        self.assertTrue(receipt["partial_record"])
+
+    def test_rotation_and_unicode_tail_are_bounded(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory) / "rollout.jsonl"
+            path.write_text(
+                "\n".join(
+                    json.dumps({"type": "event_msg", "payload": {"message": "snowman \u2603"}})
+                    for _ in range(100)
+                )
+            )
+            _records, first = MODULE.read_log(path, 512, None)
+            path.replace(path.with_suffix(".old"))
+            path.write_text(
+                json.dumps(event("2026-09-08T00:01:00Z", "event_msg", "task_complete"))
+            )
+            records, rotated = MODULE.read_log(path, 512, first)
+        self.assertEqual(rotated["mode"], "tail")
+        self.assertLessEqual(rotated["bytes_read"], 512)
+        self.assertEqual(MODULE.summarize_records(records)["state"], "completed")
+
+    def test_process_identity_does_not_fall_back_to_cwd_or_keywords(self):
+        thread_id = "0199abcd-1234-5678-9abc-0123456789ab"
+        processes = {
+            10: (1, "zsh"),
+            11: (10, f"codex resume {thread_id}"),
+            20: (1, "zsh"),
+            21: (20, "codex exec unrelated CI failure"),
+        }
+        pane = {"pane": "L1.1", "pane_id": "%1", "pid": "10"}
+        rows = {thread_id: {"id": thread_id, "rollout_path": "/tmp/exact.jsonl"}}
+        exact = MODULE.resolve_pane_identity(pane, processes, {}, rows)
+        unrelated = MODULE.resolve_pane_identity({**pane, "pid": "20"}, processes, {}, rows)
+        self.assertEqual(exact["status"], "exact")
+        self.assertEqual(exact["agent_pid"], 11)
+        self.assertEqual(unrelated["status"], "unknown")
+        self.assertEqual(unrelated["reason"], "unmatched")
+
+    def test_conflicting_threads_are_unknown(self):
+        first = "0199abcd-1234-5678-9abc-0123456789ab"
+        second = "0199abcd-1234-5678-9abc-0123456789ac"
+        processes = {
+            10: (1, "zsh"),
+            11: (10, f"codex resume {first}"),
+            12: (10, f"codex resume {second}"),
+        }
+        pane = {"pane": "L1.1", "pane_id": "%1", "pid": "10"}
+        identity = MODULE.resolve_pane_identity(pane, processes, {}, {})
+        self.assertEqual(identity["status"], "unknown")
+        self.assertEqual(identity["reason"], "ambiguous")
+
+    def test_explicit_thread_still_requires_one_exact_agent_pid(self):
+        thread_id = "0199abcd-1234-5678-9abc-0123456789ab"
+        pane = {"pane": "L1.1", "pane_id": "%1", "pid": "10"}
+        rows = {thread_id: {"id": thread_id, "rollout_path": "/tmp/exact.jsonl"}}
+        missing = MODULE.resolve_pane_identity(pane, {10: (1, "zsh")}, {"L1.1": thread_id}, rows)
+        exact = MODULE.resolve_pane_identity(
+            pane,
+            {10: (1, "zsh"), 11: (10, "codex")},
+            {"L1.1": thread_id},
+            rows,
+        )
+        self.assertEqual(missing["reason"], "agent-pid-unproven")
+        self.assertEqual(exact["status"], "exact")
+        self.assertEqual(exact["agent_pid"], 11)
+
+    def test_new_progress_overrides_earlier_same_turn_error(self):
+        records = [
+            event("2026-09-08T00:00:00Z", "event_msg", "task_started", id="turn-1"),
+            event("2026-09-08T00:00:01Z", "event_msg", "stream_error"),
+            event("2026-09-08T00:00:02Z", "event_msg", "agent_message", message="recovered"),
+        ]
+        self.assertEqual(MODULE.summarize_records(records)["state"], "active-progress")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot_test.py
+++ b/skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot_test.py
@@ -145,6 +145,33 @@ class LaneSnapshotTest(unittest.TestCase):
         ]
         self.assertEqual(MODULE.summarize_records(records)["state"], "active-progress")
 
+    def test_incremental_token_event_preserves_previous_turn_summary(self):
+        previous = {
+            "state": "active-progress",
+            "turn_id": "turn-1",
+            "latest_timestamp": "2026-09-08T00:00:01Z",
+            "latest": "still working",
+            "events": 4,
+            "tool_calls": 1,
+            "tool_outputs": 1,
+            "token_updates": 1,
+            "changed": True,
+        }
+        records = [event("2026-09-08T00:00:02Z", "event_msg", "token_count")]
+        summary = MODULE.summarize_records(records, previous)
+        self.assertEqual(summary["state"], "active-progress")
+        self.assertEqual(summary["turn_id"], "turn-1")
+        self.assertEqual(summary["latest"], "still working")
+        self.assertEqual(summary["events"], 5)
+        self.assertEqual(summary["token_updates"], 2)
+
+    def test_default_activity_projection_redacts_latest_message(self):
+        latest = f"path={pathlib.Path.home()}/private token=secret-value"
+        projected = MODULE.project_activity({"state": "active-progress", "latest": latest}, False)
+        self.assertNotIn(str(pathlib.Path.home()), projected["latest"])
+        self.assertNotIn("secret-value", projected["latest"])
+        self.assertIn("<redacted-secret>", projected["latest"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- bound lane snapshots to exact pane, process, thread, and newest-turn identity while preserving cursor state
- add bounded goal activity windows, resumed-session coverage, counter reset handling, and explicit partial-fleet failure
- document reusable checkpoint and artifact budgets through existing operational skills without introducing a state daemon

## Validation

- `make validate`
- `make check-generated`
- `pre-commit run --all-files`
- `make test`
- `python3 skills/codex-goal-mining/scripts/codex-goal-report-test.py` (9 tests)
- `python3 skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot_test.py` (10 tests)
- `git diff --check origin/main...HEAD`

## Scope

- source and documentation only
- no skill installation, fleet mutation, session change, or persistent audit output
