### PR TITLE
fix(pr-batch): stream candidate hydration without intermediate files

### DIFF
--- a/skills/openclaw-pr-batch-sweep/SKILL.md
+++ b/skills/openclaw-pr-batch-sweep/SKILL.md
@@ -49,13 +49,30 @@ Compose the repository skills instead of duplicating them:
    - Start with `gitcrawl`; verify live state with `ghx`. If `gitcrawl` is stale, malformed, or unavailable, fall through immediately to live `ghx`.
    - Run discovery and hydration shell calls serially on the maintainer host. Do not fan out `gitcrawl`, `ghx`, or per-PR REST calls in parallel.
    - Fetch at least 100 open PRs. Widen toward 1000 when the strict filter yields fewer than 20.
-   - Write discovery JSON to a file and set `OPEN_PRS_JSON` to that path. The ranker accepts either a raw PR array or gitcrawl's `{ "threads": [...] }` envelope. It normalizes `labels_json`, `author_login`, and `is_draft`; do not strip those fields before ranking.
+   - Pipe discovery JSON into the ranker. It accepts a raw PR array or gitcrawl's `{ "threads": [...] }` envelope. Keep `labels_json`, `author_login`, and `is_draft` for normalization.
    - Combine `handled_refs` and `explicit_skips` into comma-separated `HANDLED_PRS`. Numbers, `#123`, and full pull-request URLs are accepted.
-   - Run `scripts/rank-candidates.mjs --input "$OPEN_PRS_JSON" --limit 40 --batch-size 20 --decision-ledger references/decision-ledger.json --exclude "$HANDLED_PRS"` as a first-pass noise filter.
-   - Set `HYDRATED_PRS_JSON` to a second JSON file, then hydrate the top 30-40 with `scripts/hydrate-candidates.mjs --input <ranked.json> --output "$HYDRATED_PRS_JSON"`. It serially merges authoritative REST author association, file count, merge state, paginated file deltas, and live check rollups while retrying unresolved mergeability.
+   - Pipe the first ranking into `scripts/hydrate-candidates.mjs --input -`, then rank its stdout with `--hydrated`. Hydration remains serial and includes REST metadata, paginated file deltas, live checks, and mergeability retries.
+   - Set `SKILL_ROOT` to this skill's directory. For live discovery, run this pipeline in Bash or Zsh:
+
+     ```bash
+     set -o pipefail
+     ghx pr list --repo openclaw/openclaw --state open --limit 100 \
+       --json number,title,url,author,labels,isDraft,state |
+       node "$SKILL_ROOT/scripts/rank-candidates.mjs" \
+         --limit 40 --batch-size 20 \
+         --decision-ledger "$SKILL_ROOT/references/decision-ledger.json" \
+         --exclude "$HANDLED_PRS" |
+       node "$SKILL_ROOT/scripts/hydrate-candidates.mjs" --input - |
+       node "$SKILL_ROOT/scripts/rank-candidates.mjs" --hydrated \
+         --decision-ledger "$SKILL_ROOT/references/decision-ledger.json" \
+         --exclude "$HANDLED_PRS"
+     ```
+
+   - Treat any nonzero pipeline status as failure. Do not act on JSON from a failed pipeline.
+   - Retain intermediate JSON only for a concrete debugging or recovery need. Explicit `--input <file>` and hydrator `--output <file>` remain available.
    - If process launch returns `EMFILE`, `Too many open files`, or another file-descriptor exhaustion error, stop spawning workers and parallel shells immediately. Let retained lanes finish, then continue from the coordinator with one shell call at a time.
    - When REST returns `mergeable: null` or an unknown merge state, retry that PR fetch up to three times with a two-second delay. If GitHub still has not resolved it, carry the PR as indeterminate instead of admitting it to the final batch.
-   - Rerun with `--input "$HYDRATED_PRS_JSON" --hydrated`. Final selection rejects missing author association, partial file hydration, dirty/conflicting state, failed checks, and high-risk changed paths.
+   - Final ranking rejects missing author association, partial file hydration, dirty/conflicting state, failed checks, and high-risk changed paths.
    - Treat pending non-routine checks as not ready. Do not admit them merely because older checks passed.
    - Risk labels are routing signals, not proof of a risky surface. Exact security/auth and availability labels are hard exclusions. A compatibility label alone still requires qualification against the title and changed paths.
    - Production-size and test/docs-only gates are intentionally deferred until the hydrated pass.

--- a/skills/openclaw-pr-batch-sweep/scripts/hydrate-candidates.mjs
+++ b/skills/openclaw-pr-batch-sweep/scripts/hydrate-candidates.mjs
@@ -24,7 +24,7 @@ for (let index = 0; index < args.length; index += 1) {
     sleepMs = Number.parseInt(args[++index] ?? "2000", 10);
   } else if (arg === "--help") {
     console.log(
-      "Usage: hydrate-candidates.mjs --input ranked.json [--output hydrated.json] [--repo owner/name] [--limit 40] [--sleep-ms 2000]",
+      "Usage: hydrate-candidates.mjs --input <ranked.json|-> [--output hydrated.json] [--repo owner/name] [--limit 40] [--sleep-ms 2000]",
     );
     process.exit(0);
   } else {
@@ -167,7 +167,7 @@ function hydrate(candidate) {
   };
 }
 
-const parsed = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+const parsed = JSON.parse(fs.readFileSync(inputPath === "-" ? 0 : inputPath, "utf8"));
 const candidates = candidateArray(parsed).slice(0, limit);
 const hydrated = [];
 

--- a/skills/openclaw-pr-batch-sweep/scripts/hydrate-candidates.test.mjs
+++ b/skills/openclaw-pr-batch-sweep/scripts/hydrate-candidates.test.mjs
@@ -6,6 +6,7 @@ import {
   chmodSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -15,18 +16,20 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const scriptPath = fileURLToPath(new URL("./hydrate-candidates.mjs", import.meta.url));
+const rankerPath = fileURLToPath(new URL("./rank-candidates.mjs", import.meta.url));
 
-test("hydrates candidates serially and retries unresolved mergeability", () => {
+test("hydrates file and stdin candidates serially without retaining pipeline output", () => {
   const directory = mkdtempSync(path.join(tmpdir(), "openclaw-hydrate-"));
   const inputPath = path.join(directory, "ranked.json");
   const fakeGhxPath = path.join(directory, "fake-ghx.mjs");
   const countPath = path.join(directory, "count");
   const logPath = path.join(directory, "calls.log");
+  const candidates = [{ number: 42, title: "fix: preserve useful behavior" }];
 
   writeFileSync(
     inputPath,
     JSON.stringify({
-      hydrationPool: [{ number: 42, title: "fix: preserve useful behavior" }],
+      hydrationPool: candidates,
     }),
   );
   writeFileSync(
@@ -35,7 +38,10 @@ test("hydrates candidates serially and retries unresolved mergeability", () => {
 import fs from "node:fs";
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.CALL_LOG, args.join(" ") + "\\n");
-if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/42") {
+if (args[0] === "pr" && args[1] === "list") {
+  console.log(${JSON.stringify(JSON.stringify(candidates))});
+  if (process.env.FAIL_DISCOVERY === "1") process.exitCode = 23;
+} else if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/42") {
   const count = Number(fs.existsSync(process.env.COUNT_FILE) ? fs.readFileSync(process.env.COUNT_FILE, "utf8") : "0") + 1;
   fs.writeFileSync(process.env.COUNT_FILE, String(count));
   console.log(JSON.stringify({
@@ -76,18 +82,23 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/42") {
   chmodSync(fakeGhxPath, 0o755);
 
   try {
+    const options = {
+      encoding: "utf8",
+      cwd: directory,
+      env: {
+        ...process.env,
+        GHX_BIN: fakeGhxPath,
+        COUNT_FILE: countPath,
+        CALL_LOG: logPath,
+        NODE_BIN: process.execPath,
+        RANKER: rankerPath,
+        HYDRATOR: scriptPath,
+      },
+    };
     const result = spawnSync(
       process.execPath,
       [scriptPath, "--input", inputPath, "--sleep-ms", "0"],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          GHX_BIN: fakeGhxPath,
-          COUNT_FILE: countPath,
-          CALL_LOG: logPath,
-        },
-      },
+      options,
     );
 
     assert.equal(result.status, 0, result.stderr);
@@ -106,6 +117,68 @@ if (args[0] === "api" && args[1] === "repos/openclaw/openclaw/pulls/42") {
     assert.match(calls[1], /files\?per_page=25&page=1/);
     assert.match(calls[2], /^pr view 42 /);
     assert.equal(calls[3], "api repos/openclaw/openclaw/pulls/42");
+
+    const filesBefore = readdirSync(directory).sort();
+    for (const input of [
+      candidates,
+      { hydrationPool: candidates },
+      { selected: candidates },
+      { threads: candidates },
+    ]) {
+      const streamed = spawnSync(
+        process.execPath,
+        [scriptPath, "--input", "-", "--sleep-ms", "0"],
+        { ...options, input: JSON.stringify(input) },
+      );
+      assert.equal(streamed.status, 0, streamed.stderr);
+      assert.deepEqual(JSON.parse(streamed.stdout), output);
+      assert.match(streamed.stderr, /^\[1\/1\] hydrate #42\n/);
+      assert.deepEqual(readdirSync(directory).sort(), filesBefore);
+    }
+
+    const pipeline = `
+"$GHX_BIN" pr list |
+  "$NODE_BIN" "$RANKER" --limit 40 --batch-size 20 |
+  "$NODE_BIN" "$HYDRATOR" --input - --sleep-ms 0 |
+  "$NODE_BIN" "$RANKER" --hydrated
+`;
+    for (const [failDiscovery, status] of [["0", 0], ["1", 23]]) {
+      const ranked = spawnSync("bash", ["-o", "pipefail", "-c", pipeline], {
+        ...options,
+        env: { ...options.env, FAIL_DISCOVERY: failDiscovery },
+      });
+      assert.equal(ranked.status, status, ranked.stderr);
+      const selection = JSON.parse(ranked.stdout);
+      assert.equal(selection.phase, "hydrated");
+      assert.deepEqual(selection.selected.map((candidate) => candidate.number), [42]);
+      assert.match(ranked.stderr, /^\[1\/1\] hydrate #42\n/);
+      assert.deepEqual(readdirSync(directory).sort(), filesBefore);
+    }
+
+    const outputPath = path.join(directory, "hydrated.json");
+    const saved = spawnSync(
+      process.execPath,
+      [scriptPath, "--input", inputPath, "--output", outputPath, "--sleep-ms", "0"],
+      options,
+    );
+    assert.equal(saved.status, 0, saved.stderr);
+    assert.equal(saved.stdout, "");
+    assert.deepEqual(JSON.parse(readFileSync(outputPath, "utf8")), output);
+
+    const callsBeforeInvalidInput = readFileSync(logPath, "utf8");
+    for (const [args, input, error] of [
+      [[], JSON.stringify(candidates), /--input is required/],
+      [["--input", "-"], "{", /SyntaxError/],
+    ]) {
+      const invalid = spawnSync(process.execPath, [scriptPath, ...args], {
+        ...options,
+        input,
+      });
+      assert.notEqual(invalid.status, 0);
+      assert.equal(invalid.stdout, "");
+      assert.match(invalid.stderr, error);
+      assert.equal(readFileSync(logPath, "utf8"), callsBeforeInvalidInput);
+    }
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Accept explicit `--input -` in the candidate hydrator, matching the ranker's existing stdin support.
- Document a discovery -> rank -> hydrate -> rank pipeline with `pipefail`, without retained intermediate JSON.
- Preserve explicit file input/output, serial hydration, retry behavior, decision ledgers, and audit watermarks.

## Validation

- `node --test skills/openclaw-pr-batch-sweep/scripts/*.test.mjs`: 78 passed.
- Regression coverage includes all four candidate envelopes, file/stdin parity, nonempty pipeline selection, upstream failure status, no extra output files, and malformed or omitted input before GitHub calls.
- `make validate`, `pre-commit run --all-files`, `make check-generated`, and `git diff --check` passed.
- Independent review of the exact commit found no issues.

## Scope

Production LOC is unchanged. Intermediate files remain available for a concrete debugging or recovery need. This draft does not install skills, change fleet configuration, remove existing files, or apply anything automatically.
