### PR TITLE
fix(semantic-slicing): make retained map output explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ validate-spec:
 
 test:
 	node --test skills/openclaw-pr-batch-sweep/scripts/*.test.mjs
+	node --test skills/semantic-slicing/scripts/*.test.mjs
 	python3 skills/codex-goal-mining/scripts/codex-goal-report-test.py
 	python3 skills/tmux-agent-lane-orchestrator/scripts/lane_snapshot_test.py
 	python3 skills/org-branch-cleanup/scripts/test_org_branch_cleanup.py

--- a/skills/semantic-slicing/SKILL.md
+++ b/skills/semantic-slicing/SKILL.md
@@ -24,7 +24,7 @@ Default stance: map locally first, rank second, spend agent/security-review budg
 
 ## Workflow
 
-1. Create a scratch run directory outside the target checkout, usually `~/.semantic-slicing/<repo>/<timestamp>`.
+1. Reuse suitable tool state. Create task-owned temporary storage only when a tool requires files.
 2. Read target repo instructions before scanning. For OpenClaw, read root `AGENTS.md`; subtree guides matter when reviewing a slice.
 3. Verify tool setup:
    - `clawpatch`: clone/build `openclaw/clawpatch`, then run `clawpatch init`, `clawpatch map`, `clawpatch status`.
@@ -36,10 +36,13 @@ Default stance: map locally first, rank second, spend agent/security-review budg
    - Deepsec regex scan for candidate threat surfaces.
    - Optional repo git overlay for CODEOWNERS routing, tracked files, code/test/doc shape, and recent churn.
    - Optional gitcrawl/discrawl lookups for historical pain around the same files, components, or symptoms.
-5. Run `scripts/semantic-map.mjs` to merge the local artifacts into `semantic-map.html` and `semantic-map.json`.
+5. Run `scripts/semantic-map.mjs` to merge the evidence into JSON on stdout.
+   - Select bounded fields for agent inspection. Do not save intermediate output by default.
+   - Use `--out <path>` only for a requested deliverable or required evidence. It retains HTML and JSON by default.
+   - Use `--format html|json|both` to select output. A single format writes only the exact `--out` path.
    - Sparse mode is on by default and omits dotfile/config trees, docs, changelog files, and mobile app trees so core review stays focused.
    - Use `--no-sparse` or `--sparse false` for the full repo; use `--sparse-exclude <csv>` and `--sparse-include <csv>` to tune the filter.
-6. Review the board in product order:
+6. When a visual board is requested, review it in product order:
    - review lanes first: semantic shape, ownership routing, development pressure, security pressure, issue pressure, support pressure,
    - focus controls second: lens and system filters that narrow the matrix without duplicating rows,
    - overall lens matrix third: the single slice-row table with comparable bars for semantic, ownership, development, security, issue, and support lenses,
@@ -52,12 +55,15 @@ Default stance: map locally first, rank second, spend agent/security-review budg
 8. Run AI only at the chosen size:
    - `clawpatch review --feature <id>` or a small `--limit`.
    - `deepsec process --files <csv>` or tightly scoped `--filter` plus `--only-slugs`.
-9. Report exact artifact paths, run IDs, counts, cost size, exclusions, and skipped expensive stages.
+9. Report retained paths, run IDs, counts, cost size, exclusions, and skipped expensive stages in chat.
+   Remove only task-owned disposable scratch when no longer needed or in use. Preserve named deliverables and recovery evidence.
 
 ## Inputs
 
 - `target_repo`: local checkout path and/or GitHub `owner/repo`.
-- `scratch_root`: local artifact directory, default `~/.semantic-slicing/<repo>/<timestamp>`.
+- `scratch_root`: optional task-owned temporary directory for tools that require physical state.
+- `out`: optional requested deliverable or required evidence path. Omit it for stdout.
+- `format`: `html`, `json`, or `both`. Default: `json` without `out`, otherwise `both`.
 - `clawpatch_repo`: local clone of `openclaw/clawpatch`, optional if `clawpatch` is already on PATH.
 - `deepsec_repo`: local clone of `vercel-labs/deepsec`, optional if `deepsec` is already on PATH.
 - `focus`: optional path prefixes, issue numbers, slugs, components, or channels to prioritize.
@@ -72,7 +78,7 @@ Default stance: map locally first, rank second, spend agent/security-review budg
 - Deepsec scan run ID, candidate counts, top slugs, and top files.
 - Optional repo overlays from `--repo`: CODEOWNERS routing, tracked files, code/test/doc shape, 90-day churn, and test-gap pressure.
 - Optional gitcrawl cluster/thread evidence and discrawl support evidence.
-- Local semantic review board: `semantic-map.html` plus machine-readable `semantic-map.json`.
+- Machine-readable semantic map on stdout by default. Retained HTML and JSON only when requested.
 - Clean semantic buckets, ownership overlay, development overlay, security overlay, issue overlay, support overlay, and normalized queues.
 - Human review lanes, focus controls, agent handoff packet, and ranked next commands per lens with cost-size rationale.
 

--- a/skills/semantic-slicing/references/workflow.md
+++ b/skills/semantic-slicing/references/workflow.md
@@ -2,16 +2,16 @@
 
 ## Scratch layout
 
-Use a run directory outside the target checkout:
+Reuse suitable existing tool state. Map inspection alone does not need a new directory.
+If Clawpatch or Deepsec requires physical state, create one task-owned temporary directory:
 
 ```bash
-RUN_ROOT="$HOME/.semantic-slicing/openclaw/$(date +%Y%m%d-%H%M%S)"
 TOOLS_ROOT="${TOOLS_ROOT:-$HOME/src}"
 TARGET_REPO="${TARGET_REPO:-$HOME/src/openclaw}"
-mkdir -p "$RUN_ROOT"
+RUN_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/semantic-slicing.XXXXXX")"
 ```
 
-Recommended layout:
+Keep only necessary tool state and file inputs there:
 
 ```text
 <run>/
@@ -19,9 +19,13 @@ Recommended layout:
   deepsec/
   gitcrawl-evidence.json
   discrawl-evidence.json
-  semantic-map.html
-  semantic-map.json
 ```
+
+Create evidence JSON inputs only when the map needs those overlays.
+Do not retain each command's output or intermediate summaries.
+Remove only this task's disposable scratch after its consumers finish.
+Preserve active state, named deliverables, and evidence needed for recovery.
+Report any retained path and its purpose in chat.
 
 ## Clawpatch
 
@@ -143,9 +147,20 @@ discrawl digest --help
 
 Avoid pulling personal or unrelated message content into reports. Summarize only the symptom evidence needed to rank the slice.
 
-## Visual map
+## Map output
 
-Generate the local review map:
+The default is JSON on stdout, with no output files or directories.
+For routine inspection, select bounded fields before sending data to an agent:
+
+```bash
+node /path/to/semantic-slicing/scripts/semantic-map.mjs \
+  --repo "$TARGET_REPO" |
+  jq '{totals, inputs: {sparse: .inputs.sparse, sparseExcludes: .inputs.sparseExcludes, sparseIncludes: .inputs.sparseIncludes}, top: [.buckets[:8][] | {name, impactScore, action}]}'
+```
+
+Use `--out` only for a requested deliverable or required evidence.
+Set `MAP_PATH` to that destination, outside disposable scratch.
+Generate a requested visual map and its JSON data:
 
 ```bash
 node /path/to/semantic-slicing/scripts/semantic-map.mjs \
@@ -155,20 +170,34 @@ node /path/to/semantic-slicing/scripts/semantic-map.mjs \
   --deepsec "$RUN_ROOT/deepsec/data/openclaw" \
   --gitcrawl "$RUN_ROOT/gitcrawl-evidence.json" \
   --discrawl "$RUN_ROOT/discrawl-evidence.json" \
-  --out "$RUN_ROOT/semantic-map.html"
+  --out "$MAP_PATH"
 ```
+
+Omit `--gitcrawl` or `--discrawl` when that evidence file is not needed.
+
+| Options | Result |
+| --- | --- |
+| No `--out` or `--format` | JSON on stdout, no files. |
+| `--format html` without `--out` | HTML on stdout, no files. |
+| `--out map.html` | HTML at `map.html` and JSON at `map.json`, as before. |
+| `--format json --out result.json` | JSON at exactly `result.json`, no HTML. |
+| `--format html --out map.html` | HTML at exactly `map.html`, no JSON. |
+| `--format both` | Requires `--out`. |
+
+Use one stable destination per deliverable. Do not create timestamped report copies for repeated inspection.
+File-write notices go to stderr, so stdout contains only the selected payload.
 
 Sparse mode is enabled by default. It omits dotfile/config trees, docs,
 changelog files, and mobile app trees so the first board focuses on core review
-surfaces. Disable it for a whole-repo board:
+surfaces. Disable it for a whole-repo inspection:
 
 ```bash
 node /path/to/semantic-slicing/scripts/semantic-map.mjs \
   --repo "$TARGET_REPO" \
   --clawpatch "$RUN_ROOT/clawpatch" \
   --deepsec "$RUN_ROOT/deepsec/data/openclaw" \
-  --out "$RUN_ROOT/semantic-map-full.html" \
-  --no-sparse
+  --no-sparse |
+  jq '{totals, top: [.buckets[:8][] | {name, impactScore, action}]}'
 ```
 
 Tune sparse mode with comma-separated path rules. `--sparse-exclude` replaces
@@ -179,9 +208,9 @@ node /path/to/semantic-slicing/scripts/semantic-map.mjs \
   --repo "$TARGET_REPO" \
   --clawpatch "$RUN_ROOT/clawpatch" \
   --deepsec "$RUN_ROOT/deepsec/data/openclaw" \
-  --out "$RUN_ROOT/semantic-map-core-plus-android.html" \
   --sparse-exclude ".github/,.vscode/,.devcontainer/,docs/,CHANGELOG.md,apps/android/,apps/ios/" \
-  --sparse-include "apps/android/"
+  --sparse-include "apps/android/" |
+  jq '{totals, inputs: {sparseIncludes: .inputs.sparseIncludes}, top: [.buckets[:8][] | {name, impactScore, action}]}'
 ```
 
 The `--repo`, `--gitcrawl`, and `--discrawl` inputs are optional. Use `--repo`
@@ -193,7 +222,7 @@ Use `--churn-since` to size the development lens. `30.days` is good for a fast
 current-sprint view; `90.days` is better for planning refactors or ownership
 reviews.
 
-The script writes both HTML and JSON. The HTML is a semantic review board:
+HTML output is a semantic review board:
 review lanes for humans first, focus controls for lens and system filtering
 second, an overall lens matrix as the single slice-row table third, a compact
 agent handoff packet fourth, and collapsible evidence tables last. The JSON contains

--- a/skills/semantic-slicing/references/workflow.md
+++ b/skills/semantic-slicing/references/workflow.md
@@ -150,9 +150,12 @@ Avoid pulling personal or unrelated message content into reports. Summarize only
 ## Map output
 
 The default is JSON on stdout, with no output files or directories.
+Use Bash or Zsh for the pipelines below. `pipefail` preserves upstream command failures.
+Do not treat output from a failed pipeline as successful evidence.
 For routine inspection, select bounded fields before sending data to an agent:
 
 ```bash
+set -o pipefail
 node /path/to/semantic-slicing/scripts/semantic-map.mjs \
   --repo "$TARGET_REPO" |
   jq '{totals, inputs: {sparse: .inputs.sparse, sparseExcludes: .inputs.sparseExcludes, sparseIncludes: .inputs.sparseIncludes}, top: [.buckets[:8][] | {name, impactScore, action}]}'
@@ -192,6 +195,7 @@ changelog files, and mobile app trees so the first board focuses on core review
 surfaces. Disable it for a whole-repo inspection:
 
 ```bash
+set -o pipefail
 node /path/to/semantic-slicing/scripts/semantic-map.mjs \
   --repo "$TARGET_REPO" \
   --clawpatch "$RUN_ROOT/clawpatch" \
@@ -204,6 +208,7 @@ Tune sparse mode with comma-separated path rules. `--sparse-exclude` replaces
 the default exclude list; `--sparse-include` re-includes matching paths:
 
 ```bash
+set -o pipefail
 node /path/to/semantic-slicing/scripts/semantic-map.mjs \
   --repo "$TARGET_REPO" \
   --clawpatch "$RUN_ROOT/clawpatch" \

--- a/skills/semantic-slicing/scripts/semantic-map.mjs
+++ b/skills/semantic-slicing/scripts/semantic-map.mjs
@@ -4,13 +4,20 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 const args = parseArgs(process.argv.slice(2));
+const outPath = args.out;
+const outputFormat = args.format ?? (outPath ? "both" : "json");
+if (!["html", "json", "both"].includes(outputFormat)) {
+  die(`invalid --format: ${outputFormat}; expected html, json, or both`);
+}
+if (outputFormat === "both" && !outPath) {
+  die("--format both requires --out <semantic-map.html>");
+}
 if (!args.clawpatch && !args.deepsec && !args.gitcrawl && !args.discrawl && !args.repo) {
   die(
-    "usage: semantic-map.mjs --clawpatch <state-dir> --deepsec <data/project> --out <semantic-map.html> [--repo <target-repo>] [--churn-since <git-date>] [--gitcrawl <json>] [--discrawl <json>] [--no-sparse|--sparse false] [--sparse-exclude <csv>] [--sparse-include <csv>]",
+    "usage: semantic-map.mjs --clawpatch <state-dir> --deepsec <data/project> [--out <path>] [--format html|json|both] [--repo <target-repo>] [--churn-since <git-date>] [--gitcrawl <json>] [--discrawl <json>] [--no-sparse|--sparse false] [--sparse-exclude <csv>] [--sparse-include <csv>]",
   );
 }
 
-const outPath = args.out ?? path.resolve(process.cwd(), "semantic-map.html");
 const defaultSparseExcludes = [
   ".github/",
   ".vscode/",
@@ -201,11 +208,20 @@ const summary = {
   topFiles: topFiles.slice(0, 100),
 };
 
-fs.mkdirSync(path.dirname(outPath), { recursive: true });
-fs.writeFileSync(outPath, renderHtml(summary), "utf8");
-fs.writeFileSync(outPath.replace(/\.html?$/u, "") + ".json", JSON.stringify(summary, null, 2) + "\n", "utf8");
-console.log(`wrote ${outPath}`);
-console.log(`wrote ${outPath.replace(/\.html?$/u, "")}.json`);
+if (!outPath) {
+  process.stdout.write(outputFormat === "html" ? renderHtml(summary) : JSON.stringify(summary, null, 2) + "\n");
+} else {
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  if (outputFormat !== "json") {
+    fs.writeFileSync(outPath, renderHtml(summary), "utf8");
+    console.error(`wrote ${outPath}`);
+  }
+  if (outputFormat !== "html") {
+    const jsonPath = outputFormat === "both" ? outPath.replace(/\.html?$/u, "") + ".json" : outPath;
+    fs.writeFileSync(jsonPath, JSON.stringify(summary, null, 2) + "\n", "utf8");
+    console.error(`wrote ${jsonPath}`);
+  }
+}
 
 function parseArgs(argv) {
   const out = {};
@@ -1065,7 +1081,7 @@ ${lensMatrix(matrixRows)}
 </section>
 
 <h2 id="handoff">Agent Handoff Packet</h2>
-<p class="note">Small, normalized, copyable payload for follow-up agents. Full data is in the sibling JSON artifact.</p>
+<p class="note">Small, normalized, copyable payload for follow-up agents. JSON output contains the full data.</p>
 <pre>${escapeHtml(JSON.stringify(handoff, null, 2))}</pre>
 
 <h2 id="evidence">Evidence Tables</h2>

--- a/skills/semantic-slicing/scripts/semantic-map.test.mjs
+++ b/skills/semantic-slicing/scripts/semantic-map.test.mjs
@@ -145,6 +145,22 @@ for (const [args, error] of [
   });
 }
 
+test("pipefail preserves map failures when the downstream consumer succeeds", (t) => {
+  const directory = fixture(t);
+  const before = footprint(directory);
+  const result = spawnSync("bash", [
+    "-c",
+    'set -o pipefail\n"$1" "$2" --format invalid | "$1" -e "process.stdin.resume()"',
+    "semantic-map-pipeline",
+    process.execPath,
+    scriptPath,
+  ], { cwd: directory, encoding: "utf8" });
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, "");
+  assert.match(result.stderr, /invalid --format/u);
+  assert.deepEqual(footprint(directory), before);
+});
+
 for (const [sparseArgs, expectedFeatures] of [
   [[], 1],
   [["--no-sparse"], 3],

--- a/skills/semantic-slicing/scripts/semantic-map.test.mjs
+++ b/skills/semantic-slicing/scripts/semantic-map.test.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(new URL("./semantic-map.mjs", import.meta.url));
+
+function fixture(t) {
+  const directory = mkdtempSync(path.join(tmpdir(), "semantic-map-test-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const writeJson = (name, value) => {
+    const target = path.join(directory, name);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, JSON.stringify(value));
+  };
+  for (const [name, file] of [
+    ["auth", "src/auth/login.ts"],
+    ["docs", "docs/auth.md"],
+    ["android", "apps/android/Login.kt"],
+  ]) {
+    writeJson(`clawpatch/features/${name}.json`, {
+      featureId: name,
+      title: `${name} feature`,
+      kind: "source",
+      ownedFiles: [{ path: file }],
+      entrypoints: [{ path: file }],
+    });
+    writeJson(`deepsec/files/${name}.json`, {
+      filePath: file,
+      candidates: [{ vulnSlug: "rce" }],
+    });
+  }
+  writeJson("issues.json", [{ id: 123, title: "src/auth login failure" }]);
+  writeJson("support.json", [{ id: 456, title: "src/auth login report" }]);
+  return directory;
+}
+
+function run(directory, args = []) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: directory,
+    encoding: "utf8",
+  });
+}
+
+function inputs() {
+  return ["--clawpatch", "clawpatch", "--deepsec", "deepsec", "--gitcrawl", "issues.json", "--discrawl", "support.json"];
+}
+
+function model(output) {
+  const result = JSON.parse(output);
+  delete result.generatedAt;
+  return result;
+}
+
+function footprint(directory) {
+  return readdirSync(directory, { recursive: true })
+    .sort()
+    .map((name) => {
+      const stat = statSync(path.join(directory, name));
+      return { name, bytes: stat.isFile() ? stat.size : null };
+    });
+}
+
+test("default output is JSON and repeated runs leave inputs and directories unchanged", (t) => {
+  const directory = fixture(t);
+  const before = footprint(directory);
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const result = run(directory, inputs());
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, "");
+    assert.equal(JSON.parse(result.stdout).totals.features, 1);
+    assert.deepEqual(footprint(directory), before);
+  }
+});
+
+test("explicit --out preserves HTML plus sibling JSON and stable repeated-run footprint", (t) => {
+  const directory = fixture(t);
+  const args = [...inputs(), "--out", "maps/review.htm"];
+  const first = run(directory, args);
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(first.stdout, "");
+  assert.match(readFileSync(path.join(directory, "maps/review.htm"), "utf8"), /^<!doctype html>/u);
+  assert.equal(JSON.parse(readFileSync(path.join(directory, "maps/review.json"), "utf8")).totals.features, 1);
+  assert.deepEqual(readdirSync(path.join(directory, "maps")).sort(), ["review.htm", "review.json"]);
+  const before = footprint(directory);
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const result = run(directory, args);
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(footprint(directory), before);
+  }
+});
+
+for (const format of ["html", "json"]) {
+  test(`--format ${format} writes exactly the requested path`, (t) => {
+    const directory = fixture(t);
+    const result = run(directory, [...inputs(), "--format", format, "--out", "maps/selected.data"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "");
+    assert.deepEqual(readdirSync(path.join(directory, "maps")), ["selected.data"]);
+    const output = readFileSync(path.join(directory, "maps/selected.data"), "utf8");
+    if (format === "json") assert.equal(JSON.parse(output).totals.features, 1);
+    else assert.match(output, /^<!doctype html>/u);
+  });
+
+  test(`--format ${format} supports stdout without creating files`, (t) => {
+    const directory = fixture(t);
+    const before = footprint(directory);
+    const result = run(directory, [...inputs(), "--format", format]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, "");
+    if (format === "json") assert.equal(JSON.parse(result.stdout).totals.features, 1);
+    else assert.match(result.stdout, /^<!doctype html>/u);
+    assert.deepEqual(footprint(directory), before);
+  });
+}
+
+test("explicit both produces the same files as the default with --out", (t) => {
+  const directory = fixture(t);
+  const result = run(directory, [...inputs(), "--format", "both", "--out", "review.html"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+  assert.match(readFileSync(path.join(directory, "review.html"), "utf8"), /^<!doctype html>/u);
+  assert.equal(JSON.parse(readFileSync(path.join(directory, "review.json"), "utf8")).totals.features, 1);
+});
+
+for (const [args, error] of [
+  [["--format", "invalid", "--out", "not-created/report.html"], /invalid --format/u],
+  [["--format", "both"], /--format both requires --out/u],
+  [["--format"], /missing value for --format/u],
+]) {
+  test(`rejects ${args.join(" ")} before reading inputs or creating output`, (t) => {
+    const directory = fixture(t);
+    const before = footprint(directory);
+    const result = run(directory, ["--gitcrawl", "missing-input.json", ...args]);
+    assert.equal(result.status, 2);
+    assert.equal(result.stdout, "");
+    assert.match(result.stderr, error);
+    assert.doesNotMatch(result.stderr, /ENOENT/u);
+    assert.deepEqual(footprint(directory), before);
+  });
+}
+
+for (const [sparseArgs, expectedFeatures] of [
+  [[], 1],
+  [["--no-sparse"], 3],
+  [["--sparse-include", "apps/android/"], 2],
+  [["--sparse-exclude", "docs/"], 2],
+]) {
+  test(`output formats preserve the model and sparse metadata: ${sparseArgs.join(" ") || "default"}`, (t) => {
+    const directory = fixture(t);
+    const args = [...inputs(), ...sparseArgs];
+    const stdout = run(directory, args);
+    assert.equal(stdout.status, 0, stdout.stderr);
+    const expected = model(stdout.stdout);
+    assert.equal(expected.totals.features, expectedFeatures);
+    assert.equal(expected.totals.deepsecCandidates, expectedFeatures);
+    assert.equal(expected.totals.issueMatches, 1);
+    assert.equal(expected.totals.supportMatches, 1);
+    assert.equal(expected.inputs.sparse, !sparseArgs.includes("--no-sparse"));
+    assert.equal(expected.semanticBuckets.find((row) => row.name === "src/auth").semanticScore, 14);
+
+    for (const format of ["json", "both"]) {
+      const outputPath = format === "json" ? "selected.json" : "review.html";
+      const result = run(directory, [...args, "--format", format, "--out", outputPath]);
+      assert.equal(result.status, 0, result.stderr);
+      const jsonPath = format === "json" ? outputPath : "review.json";
+      assert.deepEqual(model(readFileSync(path.join(directory, jsonPath), "utf8")), expected);
+    }
+    const html = readFileSync(path.join(directory, "review.html"), "utf8");
+    assert.match(html, /Overall Lens Matrix/u);
+    assert.match(html, /Agent Handoff Packet/u);
+    assert.match(html, /src\/auth/u);
+  });
+}


### PR DESCRIPTION
## Summary

- Default `semantic-map.mjs` to JSON on stdout without creating output files or rendering HTML. Callers that relied on implicit files must now pass `--out`.
- Preserve explicit `--out` behavior: HTML plus sibling JSON. Add `--format html|json|both`; a single format writes exactly the requested path or stdout, and `both` requires a destination before input I/O.
- Replace automatic persistent scratch/report directories in the skill with necessary tool state, task-owned temporary storage, and bounded stdout inspection. Pipeline examples preserve failures with `pipefail`; failed output is not valid evidence.

## Validation

- Reviewed head: `2a4ca8909536f1300eba2245af774e7d004b64de`.
- Mechanical base update merges `main` at `865edebf5b617c6b1d99fc650d88d205a6911d8a`; the reviewed PR diff is unchanged.
- All 15 focused semantic-map tests pass, including repeated-run file footprints, selected formats, model/sparse metadata parity, invalid options before input I/O, and pipeline failure propagation.
- `make validate`, `pre-commit run --all-files`, `make check-generated`, and diff checks pass. STE hard findings remain at the existing baseline.
- Full `make test` passed all 229 tests on the reviewed head, including the 15 focused semantic-map tests.
- Required index generators ran with no generated metadata changes.

## Scope

- Production script: +16 net lines for explicit output routing and validation. Scoring, sparse filtering, and the visual layout are unchanged.
- No installed-skill changes, fleet deployment, retention sweeper, or cleanup of existing files.
- Draft for review; no merge or deployment requested by this PR.
